### PR TITLE
Feature - add gl-sdk4-wireguard-ipv4-only — enforce IPv4-only on WireGuard when Global IPv6 is disabled

### DIFF
--- a/gl-sdk4-wireguard-ipv4-only/Makefile
+++ b/gl-sdk4-wireguard-ipv4-only/Makefile
@@ -10,7 +10,7 @@ include ./version.mk
 
 PKG_NAME:=gl-sdk4-wireguard-ipv4-only
 PKG_VERSION:=$(strip $(call findrev))
-PKG_RELEASE:=6
+PKG_RELEASE:=8
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=GL.iNet <support@gl-inet.com>
@@ -73,9 +73,24 @@ endef
 define Package/gl-sdk4-wireguard-ipv4-only/prerm
 #!/bin/sh
 if [ -z "$${IPKG_INSTROOT}" ]; then
-	/etc/init.d/wg-noipv6 stop >/dev/null 2>&1 || true
-	/etc/init.d/wg-noipv6 disable >/dev/null 2>&1 || true
+	# Cleanup first: snapshot restore, drop-in removal, deferred coalesced
+	# reloads. This MUST happen before init.d/disable so a half-uninstall
+	# (interrupted opkg) still reverts the system to a sane state.
 	/usr/sbin/wg-noipv6 clear-all >/dev/null 2>&1 || true
+
+	# We deliberately do NOT call `/etc/init.d/wg-noipv6 stop` here.
+	# Under USE_PROCD=1 procd's stop verb issues a `ubus call service
+	# delete` for the service name, which prints "Command failed: Not
+	# found" to opkg's console because we never register a procd instance
+	# (we are a reload-only service, no daemon). `disable` alone is enough
+	# to remove the rc.d symlinks before opkg deletes the init.d script.
+	/etc/init.d/wg-noipv6 disable >/dev/null 2>&1 || true
+
+	# Drop our cron-tick entry (matched by trailing comment marker).
+	if [ -f /etc/crontabs/root ]; then
+		sed -i '/# wg-noipv6 reconcile$$/d' /etc/crontabs/root 2>/dev/null || true
+		/etc/init.d/cron reload >/dev/null 2>&1 || /etc/init.d/cron restart >/dev/null 2>&1 || true
+	fi
 fi
 exit 0
 endef

--- a/gl-sdk4-wireguard-ipv4-only/Makefile
+++ b/gl-sdk4-wireguard-ipv4-only/Makefile
@@ -10,7 +10,7 @@ include ./version.mk
 
 PKG_NAME:=gl-sdk4-wireguard-ipv4-only
 PKG_VERSION:=$(strip $(call findrev))
-PKG_RELEASE:=1
+PKG_RELEASE:=5
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=GL.iNet <support@gl-inet.com>
@@ -26,15 +26,13 @@ define Package/gl-sdk4-wireguard-ipv4-only
 endef
 
 define Package/gl-sdk4-wireguard-ipv4-only/description
- Native IPv4-only enforcement for GL.iNet's WireGuard backend, keyed
- off the existing global IPv6 toggle on /#/ipv6 -- no new GUI
- control. When IPv6 is disabled globally, every WG interface is
- forced into IPv4-only mode: IPv6 addresses are stripped from the
- kernel device and from the wireguard_server / network UCI configs,
- IPv6 entries are removed from each peer's allowed_ips/client_ip,
- an nftables (fw4) drop-in or fw3 include blocks IPv6 traffic on
- the WG interface, and hotplug + init.d hooks re-apply enforcement
- on every ifup or wireguard_server restart.
+ Keys IPv4-only WireGuard enforcement off the existing global IPv6
+ toggle on /#/ipv6, no new GUI control. When global IPv6 is disabled
+ it strips IPv6 from the kernel device and from wireguard_server /
+ network UCI (saving the originals so they can be restored), drops
+ IPv6 traffic on the WG iface via fw4 (nftables) or fw3 (ip6tables),
+ and re-applies on every ifup, wireguard_server reload, or netdev
+ add. Removing the package fully restores the prior config.
 endef
 
 define Build/Compile

--- a/gl-sdk4-wireguard-ipv4-only/Makefile
+++ b/gl-sdk4-wireguard-ipv4-only/Makefile
@@ -1,0 +1,95 @@
+#
+# Copyright (C) 2026 GL.iNet
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+# gl-sdk4-wireguard-ipv4-only
+#
+# Per-server "IPv4-only" enforcement for the GL.iNet WireGuard backend.
+# When `enable_ipv6` on a wireguard_server section is set to 0, this
+# package strips IPv6 from the WG interface, peers, sysctl and firewall
+# and keeps it that way against GUI regeneration, reboots and ifup
+# events. When the option is unset or 1, behaviour is unchanged.
+#
+
+include $(TOPDIR)/rules.mk
+include ./version.mk
+
+PKG_NAME:=gl-sdk4-wireguard-ipv4-only
+PKG_VERSION:=$(strip $(call findrev))
+PKG_RELEASE:=1
+
+PKG_LICENSE:=GPL-2.0
+PKG_MAINTAINER:=GL.iNet <support@gl-inet.com>
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/gl-sdk4-wireguard-ipv4-only
+  CATEGORY:=gl-sdk4
+  SUBMENU:=VPN
+  TITLE:=GL.iNet WireGuard IPv4-only enforcement
+  DEPENDS:=+wireguard-tools
+  PKGARCH:=all
+endef
+
+define Package/gl-sdk4-wireguard-ipv4-only/description
+ Adds per-server `enable_ipv6` handling to GL.iNet's WireGuard backend.
+ When the toggle is disabled, the WG interface is forced into IPv4-only
+ mode: IPv6 addresses are stripped from the kernel device and from the
+ wireguard_server / network UCI configs, IPv6 entries are removed from
+ each peer's allowed_ips/client_ip, an nftables (fw4) drop-in blocks
+ IPv6 traffic on the WG interface, and hotplug + init.d hooks re-apply
+ enforcement on every ifup or wireguard_server restart.
+endef
+
+define Package/gl-sdk4-wireguard-ipv4-only/conffiles
+/etc/config/wireguard_server
+endef
+
+define Build/Compile
+endef
+
+define Package/gl-sdk4-wireguard-ipv4-only/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) ./files/usr/sbin/wg-noipv6 $(1)/usr/sbin/wg-noipv6
+
+	$(INSTALL_DIR) $(1)/usr/lib/wg-noipv6
+	$(INSTALL_DATA) ./files/usr/lib/wg-noipv6/functions.sh $(1)/usr/lib/wg-noipv6/functions.sh
+
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/etc/init.d/wg-noipv6 $(1)/etc/init.d/wg-noipv6
+
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/iface
+	$(INSTALL_BIN) ./files/etc/hotplug.d/iface/99-wg-noipv6 $(1)/etc/hotplug.d/iface/99-wg-noipv6
+
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/net
+	$(INSTALL_BIN) ./files/etc/hotplug.d/net/99-wg-noipv6 $(1)/etc/hotplug.d/net/99-wg-noipv6
+
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_BIN) ./files/etc/uci-defaults/80-wg-noipv6 $(1)/etc/uci-defaults/80-wg-noipv6
+
+	$(INSTALL_DIR) $(1)/usr/lib/oui-httpd/rpc
+	$(INSTALL_DATA) ./files/usr/lib/oui-httpd/rpc/wireguard_ipv4_only $(1)/usr/lib/oui-httpd/rpc/wireguard_ipv4_only
+endef
+
+define Package/gl-sdk4-wireguard-ipv4-only/postinst
+#!/bin/sh
+if [ -z "$${IPKG_INSTROOT}" ]; then
+	/etc/init.d/wg-noipv6 enable >/dev/null 2>&1 || true
+	/etc/init.d/wg-noipv6 start >/dev/null 2>&1 || true
+fi
+exit 0
+endef
+
+define Package/gl-sdk4-wireguard-ipv4-only/prerm
+#!/bin/sh
+if [ -z "$${IPKG_INSTROOT}" ]; then
+	/etc/init.d/wg-noipv6 stop >/dev/null 2>&1 || true
+	/etc/init.d/wg-noipv6 disable >/dev/null 2>&1 || true
+	/usr/sbin/wg-noipv6 clear-all >/dev/null 2>&1 || true
+fi
+exit 0
+endef
+
+$(eval $(call BuildPackage,gl-sdk4-wireguard-ipv4-only))

--- a/gl-sdk4-wireguard-ipv4-only/Makefile
+++ b/gl-sdk4-wireguard-ipv4-only/Makefile
@@ -4,14 +4,6 @@
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
 #
-# gl-sdk4-wireguard-ipv4-only
-#
-# Per-server "IPv4-only" enforcement for the GL.iNet WireGuard backend.
-# When `enable_ipv6` on a wireguard_server section is set to 0, this
-# package strips IPv6 from the WG interface, peers, sysctl and firewall
-# and keeps it that way against GUI regeneration, reboots and ifup
-# events. When the option is unset or 1, behaviour is unchanged.
-#
 
 include $(TOPDIR)/rules.mk
 include ./version.mk
@@ -34,17 +26,15 @@ define Package/gl-sdk4-wireguard-ipv4-only
 endef
 
 define Package/gl-sdk4-wireguard-ipv4-only/description
- Adds per-server `enable_ipv6` handling to GL.iNet's WireGuard backend.
- When the toggle is disabled, the WG interface is forced into IPv4-only
- mode: IPv6 addresses are stripped from the kernel device and from the
- wireguard_server / network UCI configs, IPv6 entries are removed from
- each peer's allowed_ips/client_ip, an nftables (fw4) drop-in blocks
- IPv6 traffic on the WG interface, and hotplug + init.d hooks re-apply
- enforcement on every ifup or wireguard_server restart.
-endef
-
-define Package/gl-sdk4-wireguard-ipv4-only/conffiles
-/etc/config/wireguard_server
+ Native IPv4-only enforcement for GL.iNet's WireGuard backend, keyed
+ off the existing global IPv6 toggle on /#/ipv6 -- no new GUI
+ control. When IPv6 is disabled globally, every WG interface is
+ forced into IPv4-only mode: IPv6 addresses are stripped from the
+ kernel device and from the wireguard_server / network UCI configs,
+ IPv6 entries are removed from each peer's allowed_ips/client_ip,
+ an nftables (fw4) drop-in or fw3 include blocks IPv6 traffic on
+ the WG interface, and hotplug + init.d hooks re-apply enforcement
+ on every ifup or wireguard_server restart.
 endef
 
 define Build/Compile

--- a/gl-sdk4-wireguard-ipv4-only/Makefile
+++ b/gl-sdk4-wireguard-ipv4-only/Makefile
@@ -10,7 +10,7 @@ include ./version.mk
 
 PKG_NAME:=gl-sdk4-wireguard-ipv4-only
 PKG_VERSION:=$(strip $(call findrev))
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=GL.iNet <support@gl-inet.com>

--- a/gl-sdk4-wireguard-ipv4-only/README.md
+++ b/gl-sdk4-wireguard-ipv4-only/README.md
@@ -1,49 +1,104 @@
 # gl-sdk4-wireguard-ipv4-only
 
-Native **IPv4-only** enforcement for the GL.iNet WireGuard backend,
-keyed off the existing global IPv6 toggle on `/#/ipv6` -- no new
-GUI control. When IPv6 is disabled there, every WireGuard interface
-on the router is pinned to IPv4-only. When IPv6 is re-enabled, the
-GL.iNet default behaviour returns.
+Pins every WireGuard interface on a GL.iNet router to IPv4-only when global
+IPv6 is disabled on `/#/ipv6`. No new GUI control. When IPv6 is re-enabled
+the original UCI is restored from on-disk snapshots and stock behaviour
+returns.
 
-Reconciliation runs on every UCI change, ifup, kernel netdev
-appearance and at boot.
+## Symmetry
 
-## How "global IPv6" is detected
+The disable path is destructive: it strips IPv6 from `wireguard_server` and
+`network` and disables IPv6 on the kernel device. To make it reversible the
+originals are saved under `/etc/wg-noipv6/backup/` (mode 0700, files 0600)
+**before** anything is stripped, and replayed on enable. After a glinet
+restore the daemon is reloaded so it picks up the restored UCI.
 
-Layered fallback in `wg_global_ipv6_enabled` (first match wins):
+Snapshotted fields:
+
+* glinet: `wireguard_server.<srv>.address_v6`,
+  `wireguard_server.<peer>.client_ip`, `…allowed_ips`
+* netifd: `network.<iface>.ipv6`, IPv6 entries from `…addresses`
+
+## Uninstall
+
+`opkg remove gl-sdk4-wireguard-ipv4-only` runs `wg-noipv6 clear-all`. Order
+matters because the WireGuard daemon needs the kernel device IPv6-capable
+again before it will re-add v6 addresses:
+
+1. Tear down host-side enforcement (sysctl drop-ins, fw rules,
+   `disable_ipv6=0`).
+2. Drop the package's firewall UCI includes; reload firewall.
+3. `sysctl --system` so `/proc` reflects only the user's settings.
+4. Restore every UCI snapshot; reload `wireguard_server`.
+5. Reload `network` only if any netifd snapshot was restored.
+6. Remove `/etc/wg-noipv6/backup/` and `/var/run/wg-noipv6/`.
+
+## Global-IPv6 detection
+
+First match wins:
 
 1. `glconfig.general.enable_ipv6`
 2. `network.wan6.disabled` == `1`
 3. `network.wan6.proto` == `none`
 4. `network.wan6.auto` == `0`
-5. Default: enabled
+5. default: enabled
+
+## When sync runs
+
+| Trigger                                                              | Hook                                |
+|----------------------------------------------------------------------|-------------------------------------|
+| First boot after install                                             | `/etc/uci-defaults/80-wg-noipv6`    |
+| Boot                                                                 | `/etc/init.d/wg-noipv6` start       |
+| `uci commit` of `wireguard_server`/`network`/`firewall`/`glconfig`   | procd reload trigger                |
+| netifd `ifup` of a tracked WG interface                              | `/etc/hotplug.d/iface/99-wg-noipv6` |
+| Kernel netdev `add` for `wg*` / `*wgserver*`                         | `/etc/hotplug.d/net/99-wg-noipv6`   |
+| Manual                                                               | `wg-noipv6 sync` or RPC `sync`      |
+
+No polling. Toggling `/#/ipv6` writes `glconfig`, which is in the trigger
+list, so the IPv6 page alone drives a sync.
 
 ## CLI
 
 ```
-wg-noipv6 sync         # reconcile every WG server against global IPv6 state
-wg-noipv6 apply <dev>  # force-apply IPv4-only on a kernel device
-wg-noipv6 clear <dev>  # remove enforcement for a kernel device
-wg-noipv6 clear-all    # remove every drop-in this package owns
-wg-noipv6 status       # PASS/FAIL audit per WG server
+wg-noipv6 sync         # default; reconcile every WG section
+wg-noipv6 apply <dev>  # force IPv4-only on a kernel device
+wg-noipv6 clear <dev>  # remove enforcement on a kernel device
+wg-noipv6 clear-all    # restore snapshots and remove every drop-in
+wg-noipv6 status       # PASS/FAIL audit per section
 ```
+
+`status` audits both states: when IPv6 is disabled it verifies enforcement
+is in place; when enabled it verifies no leftover state remains.
 
 ## RPC
 
-`/usr/lib/oui-httpd/rpc/wireguard_ipv4_only` -- read-only:
+`/usr/lib/oui-httpd/rpc/wireguard_ipv4_only` (read-only):
 
-* `get_status({})` -> `{ global_ipv6_enabled, servers: [...] }`
-* `sync({})` -> `{ ok = true }`
+* `get_status({})` → `{ global_ipv6_enabled, servers: [...] }`
+* `sync({})` → `{ ok = true }`
+
+## Logging
+
+Tag `wg-noipv6` (`logread -e wg-noipv6`). Every CLI command emits exactly
+one summary line so it never looks like a no-op, plus per-key detail lines
+to syslog. Hooks set `WG_NOIPV6_QUIET=1` to suppress stderr; syslog is
+always written.
+
+```
+$ wg-noipv6 sync
+wg-noipv6: sync: global IPv6 disabled; enforced IPv4-only on 1 glinet + 0 netifd section(s)
+```
 
 ## Files
 
 ```
-/usr/sbin/wg-noipv6                          CLI
-/usr/lib/wg-noipv6/functions.sh              helper library
-/etc/init.d/wg-noipv6                        reload-only service (procd)
-/etc/hotplug.d/iface/99-wg-noipv6            netifd ifup hook
-/etc/hotplug.d/net/99-wg-noipv6              kernel netdev hook
-/etc/uci-defaults/80-wg-noipv6               first-boot bootstrap
-/usr/lib/oui-httpd/rpc/wireguard_ipv4_only   GUI RPC
+/usr/sbin/wg-noipv6                           CLI
+/usr/lib/wg-noipv6/functions.sh               helper library
+/etc/init.d/wg-noipv6                         reload-only procd service
+/etc/hotplug.d/iface/99-wg-noipv6             netifd ifup hook
+/etc/hotplug.d/net/99-wg-noipv6               kernel netdev hook
+/etc/uci-defaults/80-wg-noipv6                first-boot bootstrap
+/usr/lib/oui-httpd/rpc/wireguard_ipv4_only    GUI RPC
+/etc/wg-noipv6/backup/                        UCI snapshots (on demand)
+/var/run/wg-noipv6/                           live state files
 ```

--- a/gl-sdk4-wireguard-ipv4-only/README.md
+++ b/gl-sdk4-wireguard-ipv4-only/README.md
@@ -1,0 +1,98 @@
+# gl-sdk4-wireguard-ipv4-only
+
+Per-server **IPv4-only** enforcement for the GL.iNet WireGuard
+backend, integrated with `/etc/config/wireguard_server`.
+
+This package adds a `enable_ipv6` UCI option to each WireGuard
+`servers` section. When the option is set to `0`, IPv6 is forcibly
+suppressed on the WG interface and stays suppressed across GUI
+regeneration, ifup events, kernel device reappearance and reboots.
+When the option is `1` (or unset), behaviour is unchanged.
+
+The implementation mirrors the upstream reference
+[configure-wireguard-ipv4-only.sh](https://github.com/blackoutsecure/bos-scripts-collection/blob/main/linux/openwrt/network-security/wireguard-ipv4-only/configure-wireguard-ipv4-only.sh)
+but is wired into GL.iNet's `wireguard_server` config layout instead
+of being driven by a one-shot install / uninstall script.
+
+## UCI option
+
+```
+config servers 'main_server'
+    option enable_ipv6 '0'    # 0 = enforce IPv4-only, 1 = default
+    ...
+```
+
+The same option is recognised on `proto=wireguard` sections in
+`/etc/config/network` for routers that use the netifd layout.
+
+## What enforcement does
+
+When `enable_ipv6=0`, on every UCI change, ifup event or kernel
+netdev appearance, the package will:
+
+* Strip `address_v6` from the WG `servers` section.
+* Strip `:`-bearing entries from each peer's `client_ip` and
+  `allowed_ips` (so AllowedIPs become IPv4-only).
+* Set `network.<wg-iface>.ipv6=0` and remove IPv6 entries from
+  `network.<wg-iface>.addresses` (netifd layout only).
+* Install `/etc/sysctl.d/99-wg-noipv6-<dev>.conf` with
+  `net.ipv6.conf.<dev>.disable_ipv6 = 1`.
+* Install an nftables drop-in (`fw4`) or a fw3 firewall include
+  that drops every IPv6 packet entering, leaving or being forwarded
+  through the WG kernel device.
+* Remove any non-link-local IPv6 address currently bound to the WG
+  kernel device.
+* Re-program any kernel-side peer whose AllowedIPs still contain
+  IPv6 entries (`wg set <dev> peer <pub> allowed-ips ...`).
+
+When `enable_ipv6=1` (or unset), every drop-in we own for that
+device is removed and live state is restored to the default.
+
+## On-disk layout
+
+```
+/usr/sbin/wg-noipv6                          # CLI: sync|apply|clear|clear-all|status
+/usr/lib/wg-noipv6/functions.sh              # POSIX-sh helper library
+/etc/init.d/wg-noipv6                        # reload-only service (procd)
+/etc/hotplug.d/iface/99-wg-noipv6            # netifd ifup hook
+/etc/hotplug.d/net/99-wg-noipv6              # kernel netdev hook (glinet)
+/etc/uci-defaults/80-wg-noipv6               # first-boot bootstrap
+/usr/lib/oui-httpd/rpc/wireguard_ipv4_only   # GUI RPC adapter
+```
+
+## CLI
+
+```
+wg-noipv6 sync         # re-evaluate enable_ipv6 for every WG server
+wg-noipv6 apply <dev>  # force-apply IPv4-only on a kernel device
+wg-noipv6 clear <dev>  # remove enforcement for a kernel device
+wg-noipv6 clear-all    # remove every drop-in this package owns
+wg-noipv6 status       # PASS/FAIL audit per WG server
+```
+
+`sync` is idempotent and is what every other entry point (init.d,
+hotplug, RPC adapter) calls.
+
+## RPC
+
+The Lua adapter at `/usr/lib/oui-httpd/rpc/wireguard_ipv4_only`
+exposes:
+
+* `get_config({ server? })` -> `{ server, enable_ipv6 }`
+* `set_config({ server?, enable_ipv6 })` -> `{ server, enable_ipv6 }`
+* `get_status({})` -> `{ servers: [{ server, enable_ipv6, enforced,
+  kernel_dev, live_global_ipv6 }, ...] }`
+
+`server` defaults to the first `servers` section in
+`/etc/config/wireguard_server`, which on GL.iNet 4.x firmware is
+typically `main_server`.
+
+## Security notes
+
+* All paths interpolating a device name into root-owned drop-ins
+  (sysctl, nftables, fw3 includes) validate the name against
+  `[A-Za-z][A-Za-z0-9_-]*` first.
+* The RPC `set_config` rejects unknown server section names.
+* Peers that are IPv6-only (no IPv4 AllowedIPs at all) are left
+  untouched on the kernel side -- silently removing them would
+  unroute the peer entirely.

--- a/gl-sdk4-wireguard-ipv4-only/README.md
+++ b/gl-sdk4-wireguard-ipv4-only/README.md
@@ -1,98 +1,49 @@
 # gl-sdk4-wireguard-ipv4-only
 
-Per-server **IPv4-only** enforcement for the GL.iNet WireGuard
-backend, integrated with `/etc/config/wireguard_server`.
+Native **IPv4-only** enforcement for the GL.iNet WireGuard backend,
+keyed off the existing global IPv6 toggle on `/#/ipv6` -- no new
+GUI control. When IPv6 is disabled there, every WireGuard interface
+on the router is pinned to IPv4-only. When IPv6 is re-enabled, the
+GL.iNet default behaviour returns.
 
-This package adds a `enable_ipv6` UCI option to each WireGuard
-`servers` section. When the option is set to `0`, IPv6 is forcibly
-suppressed on the WG interface and stays suppressed across GUI
-regeneration, ifup events, kernel device reappearance and reboots.
-When the option is `1` (or unset), behaviour is unchanged.
+Reconciliation runs on every UCI change, ifup, kernel netdev
+appearance and at boot.
 
-The implementation mirrors the upstream reference
-[configure-wireguard-ipv4-only.sh](https://github.com/blackoutsecure/bos-scripts-collection/blob/main/linux/openwrt/network-security/wireguard-ipv4-only/configure-wireguard-ipv4-only.sh)
-but is wired into GL.iNet's `wireguard_server` config layout instead
-of being driven by a one-shot install / uninstall script.
+## How "global IPv6" is detected
 
-## UCI option
+Layered fallback in `wg_global_ipv6_enabled` (first match wins):
 
-```
-config servers 'main_server'
-    option enable_ipv6 '0'    # 0 = enforce IPv4-only, 1 = default
-    ...
-```
-
-The same option is recognised on `proto=wireguard` sections in
-`/etc/config/network` for routers that use the netifd layout.
-
-## What enforcement does
-
-When `enable_ipv6=0`, on every UCI change, ifup event or kernel
-netdev appearance, the package will:
-
-* Strip `address_v6` from the WG `servers` section.
-* Strip `:`-bearing entries from each peer's `client_ip` and
-  `allowed_ips` (so AllowedIPs become IPv4-only).
-* Set `network.<wg-iface>.ipv6=0` and remove IPv6 entries from
-  `network.<wg-iface>.addresses` (netifd layout only).
-* Install `/etc/sysctl.d/99-wg-noipv6-<dev>.conf` with
-  `net.ipv6.conf.<dev>.disable_ipv6 = 1`.
-* Install an nftables drop-in (`fw4`) or a fw3 firewall include
-  that drops every IPv6 packet entering, leaving or being forwarded
-  through the WG kernel device.
-* Remove any non-link-local IPv6 address currently bound to the WG
-  kernel device.
-* Re-program any kernel-side peer whose AllowedIPs still contain
-  IPv6 entries (`wg set <dev> peer <pub> allowed-ips ...`).
-
-When `enable_ipv6=1` (or unset), every drop-in we own for that
-device is removed and live state is restored to the default.
-
-## On-disk layout
-
-```
-/usr/sbin/wg-noipv6                          # CLI: sync|apply|clear|clear-all|status
-/usr/lib/wg-noipv6/functions.sh              # POSIX-sh helper library
-/etc/init.d/wg-noipv6                        # reload-only service (procd)
-/etc/hotplug.d/iface/99-wg-noipv6            # netifd ifup hook
-/etc/hotplug.d/net/99-wg-noipv6              # kernel netdev hook (glinet)
-/etc/uci-defaults/80-wg-noipv6               # first-boot bootstrap
-/usr/lib/oui-httpd/rpc/wireguard_ipv4_only   # GUI RPC adapter
-```
+1. `glconfig.general.enable_ipv6`
+2. `network.wan6.disabled` == `1`
+3. `network.wan6.proto` == `none`
+4. `network.wan6.auto` == `0`
+5. Default: enabled
 
 ## CLI
 
 ```
-wg-noipv6 sync         # re-evaluate enable_ipv6 for every WG server
+wg-noipv6 sync         # reconcile every WG server against global IPv6 state
 wg-noipv6 apply <dev>  # force-apply IPv4-only on a kernel device
 wg-noipv6 clear <dev>  # remove enforcement for a kernel device
 wg-noipv6 clear-all    # remove every drop-in this package owns
 wg-noipv6 status       # PASS/FAIL audit per WG server
 ```
 
-`sync` is idempotent and is what every other entry point (init.d,
-hotplug, RPC adapter) calls.
-
 ## RPC
 
-The Lua adapter at `/usr/lib/oui-httpd/rpc/wireguard_ipv4_only`
-exposes:
+`/usr/lib/oui-httpd/rpc/wireguard_ipv4_only` -- read-only:
 
-* `get_config({ server? })` -> `{ server, enable_ipv6 }`
-* `set_config({ server?, enable_ipv6 })` -> `{ server, enable_ipv6 }`
-* `get_status({})` -> `{ servers: [{ server, enable_ipv6, enforced,
-  kernel_dev, live_global_ipv6 }, ...] }`
+* `get_status({})` -> `{ global_ipv6_enabled, servers: [...] }`
+* `sync({})` -> `{ ok = true }`
 
-`server` defaults to the first `servers` section in
-`/etc/config/wireguard_server`, which on GL.iNet 4.x firmware is
-typically `main_server`.
+## Files
 
-## Security notes
-
-* All paths interpolating a device name into root-owned drop-ins
-  (sysctl, nftables, fw3 includes) validate the name against
-  `[A-Za-z][A-Za-z0-9_-]*` first.
-* The RPC `set_config` rejects unknown server section names.
-* Peers that are IPv6-only (no IPv4 AllowedIPs at all) are left
-  untouched on the kernel side -- silently removing them would
-  unroute the peer entirely.
+```
+/usr/sbin/wg-noipv6                          CLI
+/usr/lib/wg-noipv6/functions.sh              helper library
+/etc/init.d/wg-noipv6                        reload-only service (procd)
+/etc/hotplug.d/iface/99-wg-noipv6            netifd ifup hook
+/etc/hotplug.d/net/99-wg-noipv6              kernel netdev hook
+/etc/uci-defaults/80-wg-noipv6               first-boot bootstrap
+/usr/lib/oui-httpd/rpc/wireguard_ipv4_only   GUI RPC
+```

--- a/gl-sdk4-wireguard-ipv4-only/files/etc/hotplug.d/iface/99-wg-noipv6
+++ b/gl-sdk4-wireguard-ipv4-only/files/etc/hotplug.d/iface/99-wg-noipv6
@@ -1,10 +1,13 @@
 #!/bin/sh
-# Re-apply IPv4-only enforcement when a netifd interface comes up.
+# Re-apply IPv4-only enforcement when a tracked netifd interface comes up.
 
 [ "$ACTION" = "ifup" ] || exit 0
 [ -n "$INTERFACE" ] || exit 0
 
 . /usr/lib/wg-noipv6/functions.sh
+
+# Hotplug context: never echo to stderr, just syslog.
+export WG_NOIPV6_QUIET=1
 
 case " $(wg_list_netifd_ifaces) $(wg_list_glinet_servers) " in
 	*" ${INTERFACE} "*) wg_sync_all ;;

--- a/gl-sdk4-wireguard-ipv4-only/files/etc/hotplug.d/iface/99-wg-noipv6
+++ b/gl-sdk4-wireguard-ipv4-only/files/etc/hotplug.d/iface/99-wg-noipv6
@@ -1,7 +1,20 @@
 #!/bin/sh
-# Re-apply IPv4-only enforcement when a tracked netifd interface comes up.
+# Re-evaluate WireGuard IPv4-only enforcement on netifd state changes.
+#
+# We listen on two classes of events:
+#
+#   * ifup on a tracked WireGuard interface -- so newly-up WG sections
+#     immediately get pinned (or cleared) per the global IPv6 state.
+#
+#   * ifup/ifdown on wan6 -- this is the most reliable signal that the
+#     /#/ipv6 toggle changed. Some firmware revisions disable IPv6 by
+#     calling `ifdown wan6` directly without going through `ubus call
+#     uci commit`, which would otherwise bypass procd_add_reload_trigger.
 
-[ "$ACTION" = "ifup" ] || exit 0
+case "$ACTION" in
+	ifup|ifdown) ;;
+	*) exit 0 ;;
+esac
 [ -n "$INTERFACE" ] || exit 0
 
 . /usr/lib/wg-noipv6/functions.sh
@@ -9,6 +22,16 @@
 # Hotplug context: never echo to stderr, just syslog.
 export WG_NOIPV6_QUIET=1
 
+case "$INTERFACE" in
+	wan6|wan6_*)
+		wg_sync_all
+		exit 0
+		;;
+esac
+
+# Tracked WG sections only react to ifup; ifdown is harmless to skip
+# because enforcement is host-side and survives the down event.
+[ "$ACTION" = "ifup" ] || exit 0
 case " $(wg_list_netifd_ifaces) $(wg_list_glinet_servers) " in
 	*" ${INTERFACE} "*) wg_sync_all ;;
 esac

--- a/gl-sdk4-wireguard-ipv4-only/files/etc/hotplug.d/iface/99-wg-noipv6
+++ b/gl-sdk4-wireguard-ipv4-only/files/etc/hotplug.d/iface/99-wg-noipv6
@@ -1,28 +1,13 @@
 #!/bin/sh
-#
-# /etc/hotplug.d/iface/99-wg-noipv6
-#
 # Re-apply IPv4-only enforcement when a netifd interface comes up.
-# We only act on WG-related events to keep boot-time noise minimal.
 
 [ "$ACTION" = "ifup" ] || exit 0
 [ -n "$INTERFACE" ] || exit 0
 
-# Cheap pre-filter: if there are no WG sections at all, exit fast.
-if ! grep -q "proto.*wireguard" /etc/config/network 2>/dev/null \
-		&& [ ! -f /etc/config/wireguard_server ]; then
-	exit 0
-fi
-
 . /usr/lib/wg-noipv6/functions.sh
 
-# If this ifup belongs to a netifd WG interface or to the GL.iNet
-# wireguard_server section, just re-sync everything -- it is cheap
-# and idempotent.
 case " $(wg_list_netifd_ifaces) $(wg_list_glinet_servers) " in
-	*" ${INTERFACE} "*)
-		wg_sync_all
-		;;
+	*" ${INTERFACE} "*) wg_sync_all ;;
 esac
 
 exit 0

--- a/gl-sdk4-wireguard-ipv4-only/files/etc/hotplug.d/iface/99-wg-noipv6
+++ b/gl-sdk4-wireguard-ipv4-only/files/etc/hotplug.d/iface/99-wg-noipv6
@@ -1,0 +1,28 @@
+#!/bin/sh
+#
+# /etc/hotplug.d/iface/99-wg-noipv6
+#
+# Re-apply IPv4-only enforcement when a netifd interface comes up.
+# We only act on WG-related events to keep boot-time noise minimal.
+
+[ "$ACTION" = "ifup" ] || exit 0
+[ -n "$INTERFACE" ] || exit 0
+
+# Cheap pre-filter: if there are no WG sections at all, exit fast.
+if ! grep -q "proto.*wireguard" /etc/config/network 2>/dev/null \
+		&& [ ! -f /etc/config/wireguard_server ]; then
+	exit 0
+fi
+
+. /usr/lib/wg-noipv6/functions.sh
+
+# If this ifup belongs to a netifd WG interface or to the GL.iNet
+# wireguard_server section, just re-sync everything -- it is cheap
+# and idempotent.
+case " $(wg_list_netifd_ifaces) $(wg_list_glinet_servers) " in
+	*" ${INTERFACE} "*)
+		wg_sync_all
+		;;
+esac
+
+exit 0

--- a/gl-sdk4-wireguard-ipv4-only/files/etc/hotplug.d/net/99-wg-noipv6
+++ b/gl-sdk4-wireguard-ipv4-only/files/etc/hotplug.d/net/99-wg-noipv6
@@ -1,0 +1,52 @@
+#!/bin/sh
+#
+# /etc/hotplug.d/net/99-wg-noipv6
+#
+# The GL.iNet wireguard_server daemon brings up its kernel device
+# without a netifd ifup event, so the iface hotplug above never
+# fires for it. The net (netdev) hotplug is the only reliable hook
+# in that case.
+#
+# We act on `add` / `register` events for any wgN-style device, then
+# defer the heavy lifting to /usr/sbin/wg-noipv6 so the policy logic
+# stays in one place.
+
+case "$ACTION" in
+	add|register|"") ;;
+	*) exit 0 ;;
+esac
+
+[ -n "$DEVICENAME" ] || exit 0
+[ -d "/sys/class/net/$DEVICENAME" ] || exit 0
+
+# Limit ourselves to wireguard-shaped device names. Anything else
+# would be wasted work and would risk acting on names we shouldn't
+# interpolate into firewall / sysctl drop-ins.
+case "$DEVICENAME" in
+	wg*|*wgserver*) ;;
+	*) exit 0 ;;
+esac
+
+. /usr/lib/wg-noipv6/functions.sh
+
+# Reject unsafe names defensively even though the case above is
+# already conservative -- this protects the firewall / sysctl
+# drop-ins, which interpolate the device name into root-owned files.
+wg_iface_is_valid "$DEVICENAME" || exit 0
+
+# Only enforce if at least one WG server section is configured to
+# disable IPv6. Otherwise this is a no-op, which keeps the hotplug
+# cheap on devices that do not use the IPv4-only mode.
+_want_off=0
+for _srv in $(wg_list_glinet_servers); do
+	[ "$(wg_glinet_enable_ipv6 "$_srv")" = "0" ] && _want_off=1
+done
+for _iface in $(wg_list_netifd_ifaces); do
+	[ "$(wg_netifd_enable_ipv6 "$_iface")" = "0" ] && _want_off=1
+done
+
+[ "$_want_off" -eq 1 ] || exit 0
+
+/usr/sbin/wg-noipv6 apply "$DEVICENAME" >/dev/null 2>&1 || true
+
+exit 0

--- a/gl-sdk4-wireguard-ipv4-only/files/etc/hotplug.d/net/99-wg-noipv6
+++ b/gl-sdk4-wireguard-ipv4-only/files/etc/hotplug.d/net/99-wg-noipv6
@@ -1,15 +1,7 @@
 #!/bin/sh
-#
-# /etc/hotplug.d/net/99-wg-noipv6
-#
-# The GL.iNet wireguard_server daemon brings up its kernel device
-# without a netifd ifup event, so the iface hotplug above never
-# fires for it. The net (netdev) hotplug is the only reliable hook
-# in that case.
-#
-# We act on `add` / `register` events for any wgN-style device, then
-# defer the heavy lifting to /usr/sbin/wg-noipv6 so the policy logic
-# stays in one place.
+# The GL.iNet wireguard_server daemon brings its kernel device up
+# without firing a netifd ifup, so the iface hotplug never sees it.
+# This (netdev) hotplug is the only reliable hook in that case.
 
 case "$ACTION" in
 	add|register|"") ;;
@@ -19,9 +11,6 @@ esac
 [ -n "$DEVICENAME" ] || exit 0
 [ -d "/sys/class/net/$DEVICENAME" ] || exit 0
 
-# Limit ourselves to wireguard-shaped device names. Anything else
-# would be wasted work and would risk acting on names we shouldn't
-# interpolate into firewall / sysctl drop-ins.
 case "$DEVICENAME" in
 	wg*|*wgserver*) ;;
 	*) exit 0 ;;
@@ -29,23 +18,8 @@ esac
 
 . /usr/lib/wg-noipv6/functions.sh
 
-# Reject unsafe names defensively even though the case above is
-# already conservative -- this protects the firewall / sysctl
-# drop-ins, which interpolate the device name into root-owned files.
 wg_iface_is_valid "$DEVICENAME" || exit 0
-
-# Only enforce if at least one WG server section is configured to
-# disable IPv6. Otherwise this is a no-op, which keeps the hotplug
-# cheap on devices that do not use the IPv4-only mode.
-_want_off=0
-for _srv in $(wg_list_glinet_servers); do
-	[ "$(wg_glinet_enable_ipv6 "$_srv")" = "0" ] && _want_off=1
-done
-for _iface in $(wg_list_netifd_ifaces); do
-	[ "$(wg_netifd_enable_ipv6 "$_iface")" = "0" ] && _want_off=1
-done
-
-[ "$_want_off" -eq 1 ] || exit 0
+[ "$(wg_global_ipv6_enabled)" = "0" ] || exit 0
 
 /usr/sbin/wg-noipv6 apply "$DEVICENAME" >/dev/null 2>&1 || true
 

--- a/gl-sdk4-wireguard-ipv4-only/files/etc/hotplug.d/net/99-wg-noipv6
+++ b/gl-sdk4-wireguard-ipv4-only/files/etc/hotplug.d/net/99-wg-noipv6
@@ -19,8 +19,24 @@ esac
 . /usr/lib/wg-noipv6/functions.sh
 
 wg_iface_is_valid "$DEVICENAME" || exit 0
-[ "$(wg_global_ipv6_enabled)" = "0" ] || exit 0
 
-/usr/sbin/wg-noipv6 apply "$DEVICENAME" >/dev/null 2>&1 || true
+# Hotplug context: never echo to stderr, just syslog.
+export WG_NOIPV6_QUIET=1
+
+if [ "$(wg_global_ipv6_enabled)" = "0" ]; then
+	/usr/sbin/wg-noipv6 apply "$DEVICENAME" >/dev/null 2>&1 || true
+else
+	# Global IPv6 was re-enabled but we still hold leftover host-side
+	# enforcement or pending UCI snapshots. Run a full sync so the enable
+	# path can clean up and restore.
+	_stale=0
+	[ -f "${WG_NOIPV6_SYSCTL_DIR}/99-wg-noipv6-${DEVICENAME}.conf" ] && _stale=1
+	if [ "$_stale" -eq 0 ] && [ -d "$WG_NOIPV6_BACKUP_DIR" ]; then
+		for _f in "$WG_NOIPV6_BACKUP_DIR"/*.snap; do
+			[ -f "$_f" ] && { _stale=1; break; }
+		done
+	fi
+	[ "$_stale" -eq 1 ] && /usr/sbin/wg-noipv6 sync >/dev/null 2>&1 || true
+fi
 
 exit 0

--- a/gl-sdk4-wireguard-ipv4-only/files/etc/init.d/wg-noipv6
+++ b/gl-sdk4-wireguard-ipv4-only/files/etc/init.d/wg-noipv6
@@ -1,13 +1,6 @@
 #!/bin/sh /etc/rc.common
-#
-# /etc/init.d/wg-noipv6
-#
-# Runs after wireguard_server / network / firewall and re-applies
-# IPv4-only enforcement based on each WG server's enable_ipv6 toggle.
-#
-# Reload-only service: there is no long-running daemon. We just
-# re-evaluate state on boot and on UCI changes to wireguard_server,
-# network or firewall.
+# Reload-only service: re-evaluate global IPv6 state on UCI changes
+# to wireguard_server, network or firewall.
 
 START=96
 STOP=10
@@ -22,10 +15,8 @@ reload_service() {
 }
 
 stop_service() {
-	# Don't blow away enforcement on a routine `stop`: the caller
-	# may just be sequencing a network restart. Full teardown lives
-	# in `wg-noipv6 clear-all`, which is invoked by the package
-	# prerm script.
+	# Routine `stop` may just be a network restart; full teardown
+	# lives in `wg-noipv6 clear-all` (invoked by package prerm).
 	return 0
 }
 

--- a/gl-sdk4-wireguard-ipv4-only/files/etc/init.d/wg-noipv6
+++ b/gl-sdk4-wireguard-ipv4-only/files/etc/init.d/wg-noipv6
@@ -17,8 +17,15 @@ reload_service() {
 }
 
 stop_service() {
-	# Routine `stop` may just be a network restart; full teardown
-	# lives in `wg-noipv6 clear-all` (invoked by package prerm).
+	# No-op: we have no procd instance to kill. Full teardown lives in
+	# `wg-noipv6 clear-all` (invoked by package prerm). Returning early
+	# here also avoids any procd ubus chatter on a manual `stop`.
+	return 0
+}
+
+# Belt-and-suspenders for procd revisions that run service_stopped after
+# stop_service: same no-op, same reason.
+service_stopped() {
 	return 0
 }
 

--- a/gl-sdk4-wireguard-ipv4-only/files/etc/init.d/wg-noipv6
+++ b/gl-sdk4-wireguard-ipv4-only/files/etc/init.d/wg-noipv6
@@ -7,11 +7,13 @@ STOP=10
 USE_PROCD=1
 
 start_service() {
-	/usr/sbin/wg-noipv6 sync >/dev/null 2>&1 || true
+	# Hooks should only log to syslog -- never to stderr -- to keep procd
+	# logs and serial consoles clean.
+	WG_NOIPV6_QUIET=1 /usr/sbin/wg-noipv6 sync >/dev/null 2>&1 || true
 }
 
 reload_service() {
-	/usr/sbin/wg-noipv6 sync >/dev/null 2>&1 || true
+	WG_NOIPV6_QUIET=1 /usr/sbin/wg-noipv6 sync >/dev/null 2>&1 || true
 }
 
 stop_service() {
@@ -24,4 +26,5 @@ service_triggers() {
 	procd_add_reload_trigger "wireguard_server"
 	procd_add_reload_trigger "network"
 	procd_add_reload_trigger "firewall"
+	procd_add_reload_trigger "glconfig"
 }

--- a/gl-sdk4-wireguard-ipv4-only/files/etc/init.d/wg-noipv6
+++ b/gl-sdk4-wireguard-ipv4-only/files/etc/init.d/wg-noipv6
@@ -1,0 +1,36 @@
+#!/bin/sh /etc/rc.common
+#
+# /etc/init.d/wg-noipv6
+#
+# Runs after wireguard_server / network / firewall and re-applies
+# IPv4-only enforcement based on each WG server's enable_ipv6 toggle.
+#
+# Reload-only service: there is no long-running daemon. We just
+# re-evaluate state on boot and on UCI changes to wireguard_server,
+# network or firewall.
+
+START=96
+STOP=10
+USE_PROCD=1
+
+start_service() {
+	/usr/sbin/wg-noipv6 sync >/dev/null 2>&1 || true
+}
+
+reload_service() {
+	/usr/sbin/wg-noipv6 sync >/dev/null 2>&1 || true
+}
+
+stop_service() {
+	# Don't blow away enforcement on a routine `stop`: the caller
+	# may just be sequencing a network restart. Full teardown lives
+	# in `wg-noipv6 clear-all`, which is invoked by the package
+	# prerm script.
+	return 0
+}
+
+service_triggers() {
+	procd_add_reload_trigger "wireguard_server"
+	procd_add_reload_trigger "network"
+	procd_add_reload_trigger "firewall"
+}

--- a/gl-sdk4-wireguard-ipv4-only/files/etc/uci-defaults/80-wg-noipv6
+++ b/gl-sdk4-wireguard-ipv4-only/files/etc/uci-defaults/80-wg-noipv6
@@ -1,0 +1,29 @@
+#!/bin/sh
+#
+# /etc/uci-defaults/80-wg-noipv6
+#
+# Run-once-on-first-boot bootstrap for gl-sdk4-wireguard-ipv4-only.
+#
+# Seeds the per-server `enable_ipv6` UCI option to '1' (existing
+# GL.iNet default) on every existing wireguard_server section that
+# has not already set it, so the option always exists for the GUI
+# to read. Then triggers an initial sync.
+
+[ -f /etc/config/wireguard_server ] || exit 0
+
+# Add `option enable_ipv6 '1'` on each "servers" section if missing.
+for _srv in $(uci -q show wireguard_server 2>/dev/null \
+		| awk -F= '/=.?servers.?$/ { n = split($1, p, "."); if (n >= 2) print p[2] }' \
+		| sort -u); do
+	if [ -z "$(uci -q get "wireguard_server.${_srv}.enable_ipv6")" ]; then
+		uci -q set "wireguard_server.${_srv}.enable_ipv6=1"
+	fi
+done
+uci -q commit wireguard_server
+
+# Run the initial sync only at runtime, not while building an image.
+if [ -z "$IPKG_INSTROOT" ]; then
+	/usr/sbin/wg-noipv6 sync >/dev/null 2>&1 || true
+fi
+
+exit 0

--- a/gl-sdk4-wireguard-ipv4-only/files/etc/uci-defaults/80-wg-noipv6
+++ b/gl-sdk4-wireguard-ipv4-only/files/etc/uci-defaults/80-wg-noipv6
@@ -1,9 +1,25 @@
 #!/bin/sh
-# First-boot bootstrap: trigger an initial sync so existing routers
-# reach the right state on first boot after the package is installed.
+# First-boot bootstrap:
+#   1) install a cron-tick entry (see cmd_cron_tick in /usr/sbin/wg-noipv6
+#      for why this is needed -- some GL.iNet firmware revisions don't fire
+#      any procd/hotplug event when /#/ipv6 is toggled off);
+#   2) trigger an initial sync so existing routers reach the right state.
 
 if [ -z "$IPKG_INSTROOT" ]; then
+	# Idempotent cron entry. Tagged with a comment marker so prerm can
+	# remove just our line without disturbing the rest of /etc/crontabs/root.
+	mkdir -p /etc/crontabs
+	[ -f /etc/crontabs/root ] || : > /etc/crontabs/root
+	if ! grep -qF '# wg-noipv6 reconcile' /etc/crontabs/root 2>/dev/null; then
+		printf '%s\n' \
+			'* * * * * /usr/sbin/wg-noipv6 cron-tick >/dev/null 2>&1 # wg-noipv6 reconcile' \
+			>> /etc/crontabs/root
+		/etc/init.d/cron enable >/dev/null 2>&1 || true
+		/etc/init.d/cron reload >/dev/null 2>&1 || /etc/init.d/cron restart >/dev/null 2>&1 || true
+	fi
+
 	/usr/sbin/wg-noipv6 sync >/dev/null 2>&1 || true
 fi
 
 exit 0
+

--- a/gl-sdk4-wireguard-ipv4-only/files/etc/uci-defaults/80-wg-noipv6
+++ b/gl-sdk4-wireguard-ipv4-only/files/etc/uci-defaults/80-wg-noipv6
@@ -1,27 +1,7 @@
 #!/bin/sh
-#
-# /etc/uci-defaults/80-wg-noipv6
-#
-# Run-once-on-first-boot bootstrap for gl-sdk4-wireguard-ipv4-only.
-#
-# Seeds the per-server `enable_ipv6` UCI option to '1' (existing
-# GL.iNet default) on every existing wireguard_server section that
-# has not already set it, so the option always exists for the GUI
-# to read. Then triggers an initial sync.
+# First-boot bootstrap: trigger an initial sync so existing routers
+# reach the right state on first boot after the package is installed.
 
-[ -f /etc/config/wireguard_server ] || exit 0
-
-# Add `option enable_ipv6 '1'` on each "servers" section if missing.
-for _srv in $(uci -q show wireguard_server 2>/dev/null \
-		| awk -F= '/=.?servers.?$/ { n = split($1, p, "."); if (n >= 2) print p[2] }' \
-		| sort -u); do
-	if [ -z "$(uci -q get "wireguard_server.${_srv}.enable_ipv6")" ]; then
-		uci -q set "wireguard_server.${_srv}.enable_ipv6=1"
-	fi
-done
-uci -q commit wireguard_server
-
-# Run the initial sync only at runtime, not while building an image.
 if [ -z "$IPKG_INSTROOT" ]; then
 	/usr/sbin/wg-noipv6 sync >/dev/null 2>&1 || true
 fi

--- a/gl-sdk4-wireguard-ipv4-only/files/usr/lib/oui-httpd/rpc/wireguard_ipv4_only
+++ b/gl-sdk4-wireguard-ipv4-only/files/usr/lib/oui-httpd/rpc/wireguard_ipv4_only
@@ -1,0 +1,196 @@
+--[[
+    @object-name: wireguard_ipv4_only
+    @object-desc: GL.iNet WireGuard IPv4-only enforcement.
+
+    Companion to gl-sdk4-wireguard-ipv4-only. Reads / writes the
+    per-server `enable_ipv6` toggle on /etc/config/wireguard_server
+    and triggers /usr/sbin/wg-noipv6 sync to apply changes.
+
+    The toggle defaults to true (1) so existing dual-stack behaviour
+    is preserved for users who never touch it.
+--]]
+
+local uci = require "uci"
+
+local M = {}
+
+-- Internal: list every "servers"-typed section in wireguard_server.
+local function list_servers(c)
+    local out = {}
+    c:foreach("wireguard_server", "servers", function(s)
+        if s and s[".name"] then
+            out[#out + 1] = s[".name"]
+        end
+    end)
+    return out
+end
+
+-- Internal: normalise UCI bool / string / number into an explicit
+-- boolean. Anything not-explicitly-disabled stays enabled.
+local function as_bool(v)
+    if v == nil then return true end
+    local s = tostring(v):lower()
+    if s == "0" or s == "false" or s == "off" or s == "no" or s == "disabled" then
+        return false
+    end
+    return true
+end
+
+-- Internal: spawn `wg-noipv6 sync` in the background. Best-effort;
+-- failures are swallowed so the RPC reply still goes out promptly.
+local function trigger_sync()
+    if ngx and ngx.pipe and ngx.pipe.spawn then
+        local ok, p = pcall(ngx.pipe.spawn, { "/usr/sbin/wg-noipv6", "sync" })
+        if ok and p and p.wait then
+            pcall(p.wait, p)
+        end
+    else
+        os.execute("/usr/sbin/wg-noipv6 sync >/dev/null 2>&1")
+    end
+end
+
+--[[
+    @method-name: get_config
+    @method-desc: Get IPv6 enable state for a WireGuard server.
+
+    @in  string  server           Optional server section name.
+                                  Defaults to the first `servers`
+                                  section found.
+    @out string  server           Resolved server section name.
+    @out bool    enable_ipv6      true = IPv6 allowed (default),
+                                  false = IPv4-only enforced.
+
+    @in-example:  {"jsonrpc":"2.0","method":"call","params":["","wireguard_ipv4_only","get_config",{}],"id":1}
+    @out-example: {"jsonrpc":"2.0","id":1,"result":{"server":"main_server","enable_ipv6":true}}
+--]]
+M.get_config = function(params)
+    params = params or {}
+    local c = uci.cursor()
+    local servers = list_servers(c)
+    if #servers == 0 then
+        return { server = nil, enable_ipv6 = true }
+    end
+
+    local target = params.server
+    if target == nil or target == "" then
+        target = servers[1]
+    end
+
+    local v = c:get("wireguard_server", target, "enable_ipv6")
+    return {
+        server = target,
+        enable_ipv6 = as_bool(v),
+    }
+end
+
+--[[
+    @method-name: set_config
+    @method-desc: Toggle IPv6 on / off for a WireGuard server. When
+                  set to false the gl-sdk4-wireguard-ipv4-only
+                  enforcement (sysctl drop-in, firewall block,
+                  IPv4-only AllowedIPs / address_v6 strip) is
+                  applied. When set to true, all enforcement for
+                  this server is removed.
+
+    @in  string  server           Optional server section name.
+                                  Defaults to the first `servers`
+                                  section found.
+    @in  bool    enable_ipv6      true to allow IPv6 (default),
+                                  false to enforce IPv4-only.
+
+    @out string  server           Resolved server section name.
+    @out bool    enable_ipv6      Effective new value.
+
+    @in-example:  {"jsonrpc":"2.0","method":"call","params":["","wireguard_ipv4_only","set_config",{"enable_ipv6":false}],"id":1}
+    @out-example: {"jsonrpc":"2.0","id":1,"result":{"server":"main_server","enable_ipv6":false}}
+--]]
+M.set_config = function(params)
+    params = params or {}
+    local c = uci.cursor()
+    local servers = list_servers(c)
+    if #servers == 0 then
+        return { server = nil, enable_ipv6 = true, error = "no_wireguard_server_configured" }
+    end
+
+    local target = params.server
+    if target == nil or target == "" then
+        target = servers[1]
+    end
+
+    -- Verify the section actually exists -- never write to a
+    -- caller-controlled section name without validating it first.
+    local exists = false
+    for _, name in ipairs(servers) do
+        if name == target then exists = true; break end
+    end
+    if not exists then
+        return { server = target, enable_ipv6 = true, error = "unknown_server" }
+    end
+
+    local desired = as_bool(params.enable_ipv6)
+    local new_val = desired and "1" or "0"
+    local cur_val = c:get("wireguard_server", target, "enable_ipv6")
+    if cur_val ~= new_val then
+        c:set("wireguard_server", target, "enable_ipv6", new_val)
+        c:commit("wireguard_server")
+    end
+
+    -- Re-evaluate enforcement based on the new state. This is
+    -- idempotent and also re-runs when the value did not change.
+    trigger_sync()
+
+    return { server = target, enable_ipv6 = desired }
+end
+
+--[[
+    @method-name: get_status
+    @method-desc: Read-only snapshot of the enforcement state for
+                  every WG server section. Useful for the GUI to
+                  surface drift / "applied" indicators.
+
+    @out array   servers          One entry per server section:
+                                    { server, enable_ipv6,
+                                      enforced, kernel_dev,
+                                      live_global_ipv6 }
+
+    @in-example:  {"jsonrpc":"2.0","method":"call","params":["","wireguard_ipv4_only","get_status",{}],"id":1}
+--]]
+M.get_status = function(_)
+    local c = uci.cursor()
+    local servers = list_servers(c)
+    local out = {}
+    for _, name in ipairs(servers) do
+        local enable_ipv6 = as_bool(c:get("wireguard_server", name, "enable_ipv6"))
+        local dev = c:get("wireguard_server", name, "ifname")
+            or c:get("wireguard_server", name, "device")
+            or "wgserver"
+        local enforced = false
+        local f = io.open("/etc/sysctl.d/99-wg-noipv6-" .. dev .. ".conf", "r")
+        if f then enforced = true; f:close() end
+
+        local live_v6 = 0
+        local sys_path = "/sys/class/net/" .. dev
+        local s = io.open(sys_path .. "/ifindex", "r")
+        if s then
+            s:close()
+            local p = io.popen("ip -6 addr show dev " .. dev
+                .. " 2>/dev/null | awk '/inet6/ && $2 !~ /^fe80/' | wc -l")
+            if p then
+                local n = p:read("*n")
+                p:close()
+                live_v6 = tonumber(n) or 0
+            end
+        end
+
+        out[#out + 1] = {
+            server = name,
+            enable_ipv6 = enable_ipv6,
+            enforced = enforced,
+            kernel_dev = dev,
+            live_global_ipv6 = live_v6,
+        }
+    end
+    return { servers = out }
+end
+
+return M

--- a/gl-sdk4-wireguard-ipv4-only/files/usr/lib/oui-httpd/rpc/wireguard_ipv4_only
+++ b/gl-sdk4-wireguard-ipv4-only/files/usr/lib/oui-httpd/rpc/wireguard_ipv4_only
@@ -1,20 +1,13 @@
 --[[
     @object-name: wireguard_ipv4_only
-    @object-desc: GL.iNet WireGuard IPv4-only enforcement.
-
-    Companion to gl-sdk4-wireguard-ipv4-only. Reads / writes the
-    per-server `enable_ipv6` toggle on /etc/config/wireguard_server
-    and triggers /usr/sbin/wg-noipv6 sync to apply changes.
-
-    The toggle defaults to true (1) so existing dual-stack behaviour
-    is preserved for users who never touch it.
+    @object-desc: Read-only status surface for gl-sdk4-wireguard-ipv4-only.
+                  Toggling lives on /#/ipv6; this RPC never mutates UCI.
 --]]
 
 local uci = require "uci"
 
 local M = {}
 
--- Internal: list every "servers"-typed section in wireguard_server.
 local function list_servers(c)
     local out = {}
     c:foreach("wireguard_server", "servers", function(s)
@@ -25,20 +18,115 @@ local function list_servers(c)
     return out
 end
 
--- Internal: normalise UCI bool / string / number into an explicit
--- boolean. Anything not-explicitly-disabled stays enabled.
-local function as_bool(v)
-    if v == nil then return true end
-    local s = tostring(v):lower()
-    if s == "0" or s == "false" or s == "off" or s == "no" or s == "disabled" then
-        return false
+local function list_netifd_wg(c)
+    local out = {}
+    c:foreach("network", "interface", function(s)
+        if s and s.proto == "wireguard" and s[".name"] then
+            out[#out + 1] = s[".name"]
+        end
+    end)
+    return out
+end
+
+-- Mirror of wg_global_ipv6_enabled() in /usr/lib/wg-noipv6/functions.sh.
+local function global_ipv6_enabled(c)
+    local function as_explicit_bool(v)
+        if v == nil then return nil end
+        local s = tostring(v):lower()
+        if s == "0" or s == "false" or s == "off" or s == "no" or s == "disabled" then
+            return false
+        end
+        if s == "1" or s == "true" or s == "on" or s == "yes" or s == "enabled" then
+            return true
+        end
+        return nil
     end
+
+    local v = as_explicit_bool(c:get("glconfig", "general", "enable_ipv6"))
+    if v ~= nil then return v end
+
+    if tostring(c:get("network", "wan6", "disabled") or "") == "1" then return false end
+    if tostring(c:get("network", "wan6", "proto") or "") == "none" then return false end
+    if tostring(c:get("network", "wan6", "auto") or "") == "0" then return false end
     return true
 end
 
--- Internal: spawn `wg-noipv6 sync` in the background. Best-effort;
--- failures are swallowed so the RPC reply still goes out promptly.
-local function trigger_sync()
+local function live_global_ipv6_count(dev)
+    if not dev or dev == "" then return 0 end
+    local sentinel = io.open("/sys/class/net/" .. dev .. "/ifindex", "r")
+    if not sentinel then return 0 end
+    sentinel:close()
+    local p = io.popen("ip -6 addr show dev " .. dev
+        .. " 2>/dev/null | awk '/inet6/ && $2 !~ /^fe80/' | wc -l")
+    if not p then return 0 end
+    local n = p:read("*n")
+    p:close()
+    return tonumber(n) or 0
+end
+
+--[[
+    @method-name: get_status
+    @method-desc: Snapshot of the global IPv6 toggle and per-WG-interface
+                  enforcement state.
+
+    @out bool    global_ipv6_enabled
+    @out array   servers   { source, name, kernel_dev, enforced, live_global_ipv6 }
+
+    @in-example:  {"jsonrpc":"2.0","method":"call","params":["","wireguard_ipv4_only","get_status",{}],"id":1}
+    @out-example: {"jsonrpc":"2.0","id":1,"result":{"global_ipv6_enabled":false,"servers":[{"source":"glinet","name":"main_server","kernel_dev":"wgserver","enforced":true,"live_global_ipv6":0}]}}
+--]]
+M.get_status = function(_)
+    local c = uci.cursor()
+    local global_on = global_ipv6_enabled(c)
+
+    local out = {}
+    for _, name in ipairs(list_servers(c)) do
+        local dev = c:get("wireguard_server", name, "ifname")
+            or c:get("wireguard_server", name, "device")
+            or "wgserver"
+        local enforced = false
+        local f = io.open("/etc/sysctl.d/99-wg-noipv6-" .. dev .. ".conf", "r")
+        if f then enforced = true; f:close() end
+        out[#out + 1] = {
+            source = "glinet",
+            name = name,
+            kernel_dev = dev,
+            enforced = enforced,
+            live_global_ipv6 = live_global_ipv6_count(dev),
+        }
+    end
+
+    for _, name in ipairs(list_netifd_wg(c)) do
+        local dev = c:get("network", name, "ifname") or name
+        local enforced = false
+        local f = io.open("/etc/sysctl.d/99-wg-noipv6-" .. dev .. ".conf", "r")
+        if f then enforced = true; f:close() end
+        out[#out + 1] = {
+            source = "netifd",
+            name = name,
+            kernel_dev = dev,
+            enforced = enforced,
+            live_global_ipv6 = live_global_ipv6_count(dev),
+        }
+    end
+
+    return {
+        global_ipv6_enabled = global_on,
+        servers = out,
+    }
+end
+
+--[[
+    @method-name: sync
+    @method-desc: Trigger `wg-noipv6 sync` so enforcement applies
+                  immediately after the IPv6 page is toggled.
+
+    @out bool    ok
+
+    @in-example:  {"jsonrpc":"2.0","method":"call","params":["","wireguard_ipv4_only","sync",{}],"id":1}
+    @out-example: {"jsonrpc":"2.0","id":1,"result":{"ok":true}}
+--]]
+M.sync = function(_)
     if ngx and ngx.pipe and ngx.pipe.spawn then
         local ok, p = pcall(ngx.pipe.spawn, { "/usr/sbin/wg-noipv6", "sync" })
         if ok and p and p.wait then
@@ -47,150 +135,7 @@ local function trigger_sync()
     else
         os.execute("/usr/sbin/wg-noipv6 sync >/dev/null 2>&1")
     end
-end
-
---[[
-    @method-name: get_config
-    @method-desc: Get IPv6 enable state for a WireGuard server.
-
-    @in  string  server           Optional server section name.
-                                  Defaults to the first `servers`
-                                  section found.
-    @out string  server           Resolved server section name.
-    @out bool    enable_ipv6      true = IPv6 allowed (default),
-                                  false = IPv4-only enforced.
-
-    @in-example:  {"jsonrpc":"2.0","method":"call","params":["","wireguard_ipv4_only","get_config",{}],"id":1}
-    @out-example: {"jsonrpc":"2.0","id":1,"result":{"server":"main_server","enable_ipv6":true}}
---]]
-M.get_config = function(params)
-    params = params or {}
-    local c = uci.cursor()
-    local servers = list_servers(c)
-    if #servers == 0 then
-        return { server = nil, enable_ipv6 = true }
-    end
-
-    local target = params.server
-    if target == nil or target == "" then
-        target = servers[1]
-    end
-
-    local v = c:get("wireguard_server", target, "enable_ipv6")
-    return {
-        server = target,
-        enable_ipv6 = as_bool(v),
-    }
-end
-
---[[
-    @method-name: set_config
-    @method-desc: Toggle IPv6 on / off for a WireGuard server. When
-                  set to false the gl-sdk4-wireguard-ipv4-only
-                  enforcement (sysctl drop-in, firewall block,
-                  IPv4-only AllowedIPs / address_v6 strip) is
-                  applied. When set to true, all enforcement for
-                  this server is removed.
-
-    @in  string  server           Optional server section name.
-                                  Defaults to the first `servers`
-                                  section found.
-    @in  bool    enable_ipv6      true to allow IPv6 (default),
-                                  false to enforce IPv4-only.
-
-    @out string  server           Resolved server section name.
-    @out bool    enable_ipv6      Effective new value.
-
-    @in-example:  {"jsonrpc":"2.0","method":"call","params":["","wireguard_ipv4_only","set_config",{"enable_ipv6":false}],"id":1}
-    @out-example: {"jsonrpc":"2.0","id":1,"result":{"server":"main_server","enable_ipv6":false}}
---]]
-M.set_config = function(params)
-    params = params or {}
-    local c = uci.cursor()
-    local servers = list_servers(c)
-    if #servers == 0 then
-        return { server = nil, enable_ipv6 = true, error = "no_wireguard_server_configured" }
-    end
-
-    local target = params.server
-    if target == nil or target == "" then
-        target = servers[1]
-    end
-
-    -- Verify the section actually exists -- never write to a
-    -- caller-controlled section name without validating it first.
-    local exists = false
-    for _, name in ipairs(servers) do
-        if name == target then exists = true; break end
-    end
-    if not exists then
-        return { server = target, enable_ipv6 = true, error = "unknown_server" }
-    end
-
-    local desired = as_bool(params.enable_ipv6)
-    local new_val = desired and "1" or "0"
-    local cur_val = c:get("wireguard_server", target, "enable_ipv6")
-    if cur_val ~= new_val then
-        c:set("wireguard_server", target, "enable_ipv6", new_val)
-        c:commit("wireguard_server")
-    end
-
-    -- Re-evaluate enforcement based on the new state. This is
-    -- idempotent and also re-runs when the value did not change.
-    trigger_sync()
-
-    return { server = target, enable_ipv6 = desired }
-end
-
---[[
-    @method-name: get_status
-    @method-desc: Read-only snapshot of the enforcement state for
-                  every WG server section. Useful for the GUI to
-                  surface drift / "applied" indicators.
-
-    @out array   servers          One entry per server section:
-                                    { server, enable_ipv6,
-                                      enforced, kernel_dev,
-                                      live_global_ipv6 }
-
-    @in-example:  {"jsonrpc":"2.0","method":"call","params":["","wireguard_ipv4_only","get_status",{}],"id":1}
---]]
-M.get_status = function(_)
-    local c = uci.cursor()
-    local servers = list_servers(c)
-    local out = {}
-    for _, name in ipairs(servers) do
-        local enable_ipv6 = as_bool(c:get("wireguard_server", name, "enable_ipv6"))
-        local dev = c:get("wireguard_server", name, "ifname")
-            or c:get("wireguard_server", name, "device")
-            or "wgserver"
-        local enforced = false
-        local f = io.open("/etc/sysctl.d/99-wg-noipv6-" .. dev .. ".conf", "r")
-        if f then enforced = true; f:close() end
-
-        local live_v6 = 0
-        local sys_path = "/sys/class/net/" .. dev
-        local s = io.open(sys_path .. "/ifindex", "r")
-        if s then
-            s:close()
-            local p = io.popen("ip -6 addr show dev " .. dev
-                .. " 2>/dev/null | awk '/inet6/ && $2 !~ /^fe80/' | wc -l")
-            if p then
-                local n = p:read("*n")
-                p:close()
-                live_v6 = tonumber(n) or 0
-            end
-        end
-
-        out[#out + 1] = {
-            server = name,
-            enable_ipv6 = enable_ipv6,
-            enforced = enforced,
-            kernel_dev = dev,
-            live_global_ipv6 = live_v6,
-        }
-    end
-    return { servers = out }
+    return { ok = true }
 end
 
 return M

--- a/gl-sdk4-wireguard-ipv4-only/files/usr/lib/wg-noipv6/functions.sh
+++ b/gl-sdk4-wireguard-ipv4-only/files/usr/lib/wg-noipv6/functions.sh
@@ -1,0 +1,534 @@
+#!/bin/sh
+# shellcheck shell=ash
+#
+# /usr/lib/wg-noipv6/functions.sh
+#
+# Shared POSIX-sh helpers for the gl-sdk4-wireguard-ipv4-only package.
+#
+# Sourced by:
+#   /usr/sbin/wg-noipv6
+#   /etc/init.d/wg-noipv6
+#   /etc/hotplug.d/iface/99-wg-noipv6
+#   /etc/hotplug.d/net/99-wg-noipv6
+#
+# Layout: behaviour mirrors the upstream reference script
+# (configure-wireguard-ipv4-only.sh by Blackout Secure) but is
+# wired into GL.iNet's wireguard_server UCI config so the GUI
+# `enable_ipv6` toggle drives state directly.
+
+WG_NOIPV6_TAG="wg-noipv6"
+WG_NOIPV6_SYSCTL_DIR="/etc/sysctl.d"
+WG_NOIPV6_NFT_DIR="/etc/nftables.d"
+WG_NOIPV6_FW3_DIR="/etc/wg-noipv6/fw3"
+WG_NOIPV6_STATE_DIR="/var/run/wg-noipv6"
+WG_NOIPV6_DEFAULT_DEV="wgserver"
+
+_wg_log() {
+	logger -t "$WG_NOIPV6_TAG" "$*" 2>/dev/null || true
+}
+
+# Validate an interface name before interpolating it into firewall /
+# sysctl drop-ins. Reject anything that isn't a normal Linux netdev
+# name to avoid command injection through user-controlled UCI values.
+wg_iface_is_valid() {
+	case "$1" in
+		''|*[!A-Za-z0-9_-]*|[!A-Za-z]*) return 1 ;;
+	esac
+	return 0
+}
+
+# Echo "fw4" if nftables/fw4 is available, otherwise "fw3".
+wg_detect_fw_backend() {
+	if [ -x /sbin/fw4 ] || command -v nft >/dev/null 2>&1; then
+		printf 'fw4\n'
+	else
+		printf 'fw3\n'
+	fi
+}
+
+# List wireguard_server "servers" sections (GL.iNet layout).
+wg_list_glinet_servers() {
+	[ -f /etc/config/wireguard_server ] || return 0
+	uci -q show wireguard_server 2>/dev/null | awk -F= '
+		/=.?servers.?$/ {
+			n = split($1, parts, ".")
+			if (n >= 2) print parts[2]
+		}
+	' | sort -u
+}
+
+# List all peers sections in /etc/config/wireguard_server.
+wg_list_glinet_peers() {
+	[ -f /etc/config/wireguard_server ] || return 0
+	uci -q show wireguard_server 2>/dev/null | awk -F= '
+		/=.?peers.?$/ {
+			n = split($1, parts, ".")
+			if (n >= 2) print parts[2]
+		}
+	'
+}
+
+# List netifd-managed wireguard interfaces.
+wg_list_netifd_ifaces() {
+	[ -f /etc/config/network ] || return 0
+	uci -q show network 2>/dev/null | awk -F= '
+		/\.proto=.?wireguard.?$/ {
+			n = split($1, parts, ".")
+			if (n >= 2) print parts[2]
+		}
+	' | sort -u
+}
+
+# Echo the kernel device name for the given GL.iNet server section.
+# Falls back to $WG_NOIPV6_DEFAULT_DEV ("wgserver"), which is what
+# GL.iNet firmware uses by default.
+wg_glinet_kernel_dev() {
+	_srv="$1"
+	[ -n "$_srv" ] || { printf '%s\n' "$WG_NOIPV6_DEFAULT_DEV"; return; }
+	_d="$(uci -q get "wireguard_server.${_srv}.ifname" 2>/dev/null)"
+	[ -n "$_d" ] || _d="$(uci -q get "wireguard_server.${_srv}.device" 2>/dev/null)"
+	[ -n "$_d" ] || _d="$WG_NOIPV6_DEFAULT_DEV"
+	printf '%s\n' "$_d"
+}
+
+# Echo the kernel device name for the given netifd wireguard section.
+wg_netifd_kernel_dev() {
+	_iface="$1"
+	[ -n "$_iface" ] || return 0
+	_d="$(uci -q get "network.${_iface}.ifname" 2>/dev/null)"
+	[ -n "$_d" ] || _d="$_iface"
+	printf '%s\n' "$_d"
+}
+
+# Read the per-server enable_ipv6 toggle. Defaults to 1 (IPv6 allowed)
+# so existing GL.iNet behaviour is preserved when the option is unset.
+wg_glinet_enable_ipv6() {
+	_srv="$1"
+	_v="$(uci -q get "wireguard_server.${_srv}.enable_ipv6" 2>/dev/null)"
+	case "$_v" in
+		0|no|off|false|disabled) printf '0\n' ;;
+		*) printf '1\n' ;;
+	esac
+}
+
+# Read per-section enable_ipv6 toggle for netifd wireguard ifaces.
+# Same defaulting rule as the glinet version.
+wg_netifd_enable_ipv6() {
+	_iface="$1"
+	_v="$(uci -q get "network.${_iface}.enable_ipv6" 2>/dev/null)"
+	case "$_v" in
+		0|no|off|false|disabled) printf '0\n' ;;
+		*) printf '1\n' ;;
+	esac
+}
+
+# Strip non-link-local IPv6 addresses from a live kernel device.
+# Echoes the count of addresses removed.
+wg_strip_live_ipv6() {
+	_dev="$1"
+	[ -n "$_dev" ] || { printf '0\n'; return 0; }
+	[ -d "/sys/class/net/$_dev" ] || { printf '0\n'; return 0; }
+	_n=0
+	for _a in $(ip -6 addr show dev "$_dev" 2>/dev/null \
+			| awk '/inet6/ && $2 !~ /^fe80/ {print $2}'); do
+		ip -6 addr del "$_a" dev "$_dev" 2>/dev/null && _n=$((_n+1))
+	done
+	printf '%s\n' "$_n"
+}
+
+# Drop ":"-bearing entries from a comma-separated list. Used for the
+# GL.iNet peer client_ip / allowed_ips fields which carry both the
+# IPv4 and IPv6 sides as a single CSV string.
+wg_strip_v6_from_csv() {
+	printf '%s' "$1" | awk -v RS=',' '{
+		gsub(/^[ \t]+|[ \t]+$/, "", $0)
+		if (length($0) == 0) next
+		if (index($0, ":") > 0) next
+		if (out == "") out = $0
+		else            out = out "," $0
+	} END { print out }'
+}
+
+# Strip IPv6 entries from netifd network.<iface>.addresses list.
+wg_strip_netifd_ipv6_addrs() {
+	_iface="$1"
+	_addrs=""
+	for _a in $(uci -q get "network.${_iface}.addresses" 2>/dev/null); do
+		case "$_a" in *:*) ;; *) _addrs="$_addrs $_a" ;; esac
+	done
+	uci -q delete "network.${_iface}.addresses" 2>/dev/null || true
+	for _a in $_addrs; do
+		uci -q add_list "network.${_iface}.addresses=$_a" 2>/dev/null || true
+	done
+}
+
+# Reconcile the live kernel WG peer state to drop IPv6 entries from
+# each peer's AllowedIPs. Required because wireguard_server may not
+# re-push peer programming after a UCI rewrite + restart -- existing
+# sessions keep their old AllowedIPs in the kernel until the peer
+# re-handshakes. Echoes the count of peers updated.
+wg_reconcile_kernel_peers_ipv4() {
+	_dev="$1"
+	[ -n "$_dev" ] || { printf '0\n'; return 0; }
+	[ -d "/sys/class/net/$_dev" ] || { printf '0\n'; return 0; }
+	command -v wg >/dev/null 2>&1 || { printf '0\n'; return 0; }
+	_tmp="/tmp/.wg_noipv6_peers.$$"
+	wg show "$_dev" allowed-ips >"$_tmp" 2>/dev/null || {
+		rm -f "$_tmp"; printf '0\n'; return 0
+	}
+	_updated=0
+	# Each line: "<pubkey>\t<ip1> <ip2> ..." or "<pubkey>\t(none)"
+	while IFS="$(printf '\t')" read -r _pub _ips; do
+		[ -n "$_pub" ] || continue
+		case "$_ips" in '(none)'|'') continue ;; esac
+		_new=""
+		_had_v6=0
+		for _ip in $_ips; do
+			case "$_ip" in
+				*:*) _had_v6=1 ;;
+				'') ;;
+				*)  _new="${_new:+$_new,}$_ip" ;;
+			esac
+		done
+		[ "$_had_v6" -eq 1 ] || continue
+		if [ -z "$_new" ]; then
+			# Peer is IPv6-only -- refuse to clear so we don't
+			# accidentally unroute the peer entirely.
+			_wg_log "kernel peer ${_pub} has only IPv6 allowed-ips; not modifying"
+			continue
+		fi
+		if wg set "$_dev" peer "$_pub" allowed-ips "$_new" 2>/dev/null; then
+			_updated=$((_updated+1))
+		fi
+	done <"$_tmp"
+	rm -f "$_tmp"
+	printf '%s\n' "$_updated"
+}
+
+# Pin a single GL.iNet wireguard_server section to IPv4-only:
+#  - clear address_v6 on the server section
+#  - strip ":"-bearing entries from each peer's client_ip / allowed_ips
+# Returns 0 if anything changed, 1 otherwise.
+wg_pin_glinet_ipv4() {
+	_srv="$1"
+	[ -n "$_srv" ] || return 1
+	[ -n "$(uci -q get "wireguard_server.${_srv}")" ] || return 1
+	_changed=0
+
+	# 1) server section: clear address_v6
+	_v6srv="$(uci -q get "wireguard_server.${_srv}.address_v6" 2>/dev/null)"
+	if [ -n "$_v6srv" ]; then
+		uci -q delete "wireguard_server.${_srv}.address_v6"
+		_changed=1
+		_wg_log "cleared wireguard_server.${_srv}.address_v6 (was: $_v6srv)"
+	fi
+
+	# 2) peers: strip ":"-bearing entries from CSV options
+	for _p in $(wg_list_glinet_peers); do
+		for _key in client_ip allowed_ips; do
+			_cur="$(uci -q get "wireguard_server.${_p}.${_key}" 2>/dev/null)"
+			[ -n "$_cur" ] || continue
+			_new="$(wg_strip_v6_from_csv "$_cur")"
+			if [ "$_cur" != "$_new" ]; then
+				if [ -n "$_new" ]; then
+					uci -q set "wireguard_server.${_p}.${_key}=$_new"
+				else
+					uci -q delete "wireguard_server.${_p}.${_key}"
+				fi
+				_changed=1
+				_wg_log "wireguard_server.${_p}.${_key}: stripped IPv6 (now: ${_new:-<unset>})"
+			fi
+		done
+	done
+
+	[ "$_changed" -eq 1 ] && uci -q commit wireguard_server
+	return 0
+}
+
+# Pin a single netifd wireguard section to IPv4-only:
+#  - set network.<iface>.ipv6=0
+#  - strip IPv6 entries from network.<iface>.addresses
+wg_pin_netifd_ipv4() {
+	_iface="$1"
+	[ -n "$_iface" ] || return 1
+	[ "$(uci -q get "network.${_iface}.proto")" = "wireguard" ] || return 1
+	_changed=0
+	if [ "$(uci -q get "network.${_iface}.ipv6")" != "0" ]; then
+		uci -q set "network.${_iface}.ipv6=0"
+		_changed=1
+	fi
+	_v6=0
+	for _a in $(uci -q get "network.${_iface}.addresses" 2>/dev/null); do
+		case "$_a" in *:*) _v6=$((_v6+1));; esac
+	done
+	if [ "$_v6" -gt 0 ]; then
+		wg_strip_netifd_ipv6_addrs "$_iface"
+		_changed=1
+		_wg_log "stripped $_v6 IPv6 entry/entries from network.${_iface}.addresses"
+	fi
+	[ "$_changed" -eq 1 ] && uci -q commit network
+	return 0
+}
+
+# Restore the netifd defaults for a section: drop the ipv6=0 marker
+# we set; we leave addresses alone (the GUI will re-issue them).
+wg_unpin_netifd_ipv4() {
+	_iface="$1"
+	[ -n "$_iface" ] || return 1
+	if [ "$(uci -q get "network.${_iface}.ipv6")" = "0" ]; then
+		uci -q delete "network.${_iface}.ipv6"
+		uci -q commit network
+	fi
+}
+
+# Write the per-iface sysctl drop-in that pins disable_ipv6=1 on the
+# WG kernel device. Idempotent.
+wg_apply_sysctl() {
+	_dev="$1"
+	wg_iface_is_valid "$_dev" || return 1
+	mkdir -p "$WG_NOIPV6_SYSCTL_DIR"
+	_path="${WG_NOIPV6_SYSCTL_DIR}/99-wg-noipv6-${_dev}.conf"
+	cat > "$_path" <<EOF
+# Managed by gl-sdk4-wireguard-ipv4-only; do not edit by hand.
+net.ipv6.conf.${_dev}.disable_ipv6 = 1
+EOF
+	sysctl -p "$_path" >/dev/null 2>&1 || true
+}
+
+wg_remove_sysctl() {
+	_dev="$1"
+	wg_iface_is_valid "$_dev" || return 1
+	_path="${WG_NOIPV6_SYSCTL_DIR}/99-wg-noipv6-${_dev}.conf"
+	[ -f "$_path" ] && rm -f "$_path"
+	[ -f "/proc/sys/net/ipv6/conf/$_dev/disable_ipv6" ] \
+		&& echo 0 > "/proc/sys/net/ipv6/conf/$_dev/disable_ipv6" 2>/dev/null || true
+}
+
+# Install the fw4 nftables drop-in that blocks IPv6 traffic on the
+# WG kernel device.
+wg_apply_firewall_fw4() {
+	_dev="$1"
+	wg_iface_is_valid "$_dev" || return 1
+	mkdir -p "$WG_NOIPV6_NFT_DIR"
+	_path="${WG_NOIPV6_NFT_DIR}/99-wg-noipv6-${_dev}.nft"
+	cat > "$_path" <<EOF
+# Managed by gl-sdk4-wireguard-ipv4-only; do not edit by hand.
+chain wg_noipv6_input_${_dev} {
+	type filter hook input priority -1; policy accept;
+	iifname "${_dev}" meta nfproto ipv6 drop
+}
+chain wg_noipv6_forward_${_dev} {
+	type filter hook forward priority -1; policy accept;
+	iifname "${_dev}" meta nfproto ipv6 drop
+	oifname "${_dev}" meta nfproto ipv6 drop
+}
+chain wg_noipv6_output_${_dev} {
+	type filter hook output priority -1; policy accept;
+	oifname "${_dev}" meta nfproto ipv6 drop
+}
+EOF
+	/etc/init.d/firewall reload >/dev/null 2>&1 || true
+}
+
+wg_remove_firewall_fw4() {
+	_dev="$1"
+	wg_iface_is_valid "$_dev" || return 1
+	_path="${WG_NOIPV6_NFT_DIR}/99-wg-noipv6-${_dev}.nft"
+	[ -f "$_path" ] && rm -f "$_path"
+	/etc/init.d/firewall reload >/dev/null 2>&1 || true
+}
+
+# Install the fw3 firewall include + ip6tables drop rules.
+wg_apply_firewall_fw3() {
+	_dev="$1"
+	wg_iface_is_valid "$_dev" || return 1
+	mkdir -p "$WG_NOIPV6_FW3_DIR"
+	_path="${WG_NOIPV6_FW3_DIR}/wg-noipv6-${_dev}.sh"
+	cat > "$_path" <<EOF
+#!/bin/sh
+# Managed by gl-sdk4-wireguard-ipv4-only; do not edit by hand.
+WG_DEV="${_dev}"
+ip6tables -D forwarding_rule -i "\$WG_DEV" -j DROP 2>/dev/null
+ip6tables -D forwarding_rule -o "\$WG_DEV" -j DROP 2>/dev/null
+ip6tables -D input_rule      -i "\$WG_DEV" -j DROP 2>/dev/null
+ip6tables -D output_rule     -o "\$WG_DEV" -j DROP 2>/dev/null
+ip6tables -I forwarding_rule -i "\$WG_DEV" -j DROP
+ip6tables -I forwarding_rule -o "\$WG_DEV" -j DROP
+ip6tables -I input_rule      -i "\$WG_DEV" -j DROP
+ip6tables -I output_rule     -o "\$WG_DEV" -j DROP
+EOF
+	chmod 0755 "$_path"
+	_inc_name="wg_noipv6_${_dev}"
+	uci -q delete "firewall.${_inc_name}" 2>/dev/null || true
+	uci -q set "firewall.${_inc_name}=include"
+	uci -q set "firewall.${_inc_name}.path=$_path"
+	uci -q set "firewall.${_inc_name}.reload=1"
+	uci -q commit firewall
+	/etc/init.d/firewall reload >/dev/null 2>&1 || true
+}
+
+wg_remove_firewall_fw3() {
+	_dev="$1"
+	wg_iface_is_valid "$_dev" || return 1
+	_path="${WG_NOIPV6_FW3_DIR}/wg-noipv6-${_dev}.sh"
+	[ -f "$_path" ] && rm -f "$_path"
+	_inc_name="wg_noipv6_${_dev}"
+	if [ -n "$(uci -q get "firewall.${_inc_name}")" ]; then
+		uci -q delete "firewall.${_inc_name}"
+		uci -q commit firewall
+	fi
+	if command -v ip6tables >/dev/null 2>&1; then
+		ip6tables -D forwarding_rule -i "$_dev" -j DROP 2>/dev/null || true
+		ip6tables -D forwarding_rule -o "$_dev" -j DROP 2>/dev/null || true
+		ip6tables -D input_rule      -i "$_dev" -j DROP 2>/dev/null || true
+		ip6tables -D output_rule     -o "$_dev" -j DROP 2>/dev/null || true
+	fi
+	/etc/init.d/firewall reload >/dev/null 2>&1 || true
+}
+
+# Backend dispatcher.
+wg_apply_firewall() {
+	case "$(wg_detect_fw_backend)" in
+		fw4) wg_apply_firewall_fw4 "$1" ;;
+		*)   wg_apply_firewall_fw3 "$1" ;;
+	esac
+}
+
+wg_remove_firewall() {
+	case "$(wg_detect_fw_backend)" in
+		fw4) wg_remove_firewall_fw4 "$1" ;;
+		*)   wg_remove_firewall_fw3 "$1" ;;
+	esac
+}
+
+# Apply IPv4-only enforcement for one GL.iNet server section.
+# Expects a validated kernel device name; safe to call repeatedly.
+wg_apply_glinet() {
+	_srv="$1"
+	_dev="$2"
+	wg_iface_is_valid "$_dev" || {
+		_wg_log "refusing to act on invalid iface name '$_dev' for $_srv"
+		return 1
+	}
+	wg_pin_glinet_ipv4 "$_srv"
+	wg_apply_sysctl "$_dev"
+	wg_apply_firewall "$_dev"
+	_n="$(wg_strip_live_ipv6 "$_dev")"
+	[ "$_n" -gt 0 ] && _wg_log "removed $_n IPv6 address(es) from $_dev"
+	_p="$(wg_reconcile_kernel_peers_ipv4 "$_dev")"
+	[ "$_p" -gt 0 ] && _wg_log "reconciled $_p kernel peer(s) on $_dev to IPv4-only"
+	mkdir -p "$WG_NOIPV6_STATE_DIR"
+	printf '%s\n' "$_dev" > "${WG_NOIPV6_STATE_DIR}/glinet-${_srv}.dev"
+	return 0
+}
+
+# Apply IPv4-only enforcement for one netifd wireguard interface.
+wg_apply_netifd() {
+	_iface="$1"
+	_dev="$2"
+	wg_iface_is_valid "$_dev" || {
+		_wg_log "refusing to act on invalid iface name '$_dev' for $_iface"
+		return 1
+	}
+	wg_pin_netifd_ipv4 "$_iface"
+	wg_apply_sysctl "$_dev"
+	wg_apply_firewall "$_dev"
+	_n="$(wg_strip_live_ipv6 "$_dev")"
+	[ "$_n" -gt 0 ] && _wg_log "removed $_n IPv6 address(es) from $_dev"
+	_p="$(wg_reconcile_kernel_peers_ipv4 "$_dev")"
+	[ "$_p" -gt 0 ] && _wg_log "reconciled $_p kernel peer(s) on $_dev to IPv4-only"
+	mkdir -p "$WG_NOIPV6_STATE_DIR"
+	printf '%s\n' "$_dev" > "${WG_NOIPV6_STATE_DIR}/netifd-${_iface}.dev"
+	return 0
+}
+
+# Remove enforcement for a previously-pinned device.
+wg_clear_dev() {
+	_dev="$1"
+	wg_iface_is_valid "$_dev" || return 1
+	wg_remove_sysctl "$_dev"
+	wg_remove_firewall "$_dev"
+}
+
+# Walk every wireguard server section and apply or clear based on the
+# per-section enable_ipv6 toggle. This is the entry point used by
+# `/etc/init.d/wg-noipv6 reload`, the uci-defaults bootstrap, the RPC
+# adapter and the iface hotplug script.
+wg_sync_all() {
+	mkdir -p "$WG_NOIPV6_STATE_DIR"
+
+	# GL.iNet wireguard_server layout
+	for _srv in $(wg_list_glinet_servers); do
+		_dev="$(wg_glinet_kernel_dev "$_srv")"
+		wg_iface_is_valid "$_dev" || continue
+		_state="${WG_NOIPV6_STATE_DIR}/glinet-${_srv}.dev"
+		if [ "$(wg_glinet_enable_ipv6 "$_srv")" = "0" ]; then
+			wg_apply_glinet "$_srv" "$_dev"
+		else
+			# enabled (or unset/default): tear down anything we
+			# previously installed for this server's last device.
+			if [ -f "$_state" ]; then
+				_old="$(head -n1 "$_state" 2>/dev/null)"
+				wg_iface_is_valid "$_old" && wg_clear_dev "$_old"
+				rm -f "$_state"
+			fi
+			wg_iface_is_valid "$_dev" && wg_clear_dev "$_dev"
+		fi
+	done
+
+	# netifd layout (proto=wireguard)
+	for _iface in $(wg_list_netifd_ifaces); do
+		_dev="$(wg_netifd_kernel_dev "$_iface")"
+		wg_iface_is_valid "$_dev" || continue
+		_state="${WG_NOIPV6_STATE_DIR}/netifd-${_iface}.dev"
+		if [ "$(wg_netifd_enable_ipv6 "$_iface")" = "0" ]; then
+			wg_apply_netifd "$_iface" "$_dev"
+		else
+			if [ -f "$_state" ]; then
+				_old="$(head -n1 "$_state" 2>/dev/null)"
+				wg_iface_is_valid "$_old" && wg_clear_dev "$_old"
+				rm -f "$_state"
+			fi
+			wg_unpin_netifd_ipv4 "$_iface"
+			wg_iface_is_valid "$_dev" && wg_clear_dev "$_dev"
+		fi
+	done
+}
+
+# Used at package removal time: drop every drop-in we might have
+# installed and restore default behaviour.
+wg_clear_all() {
+	if [ -d "$WG_NOIPV6_STATE_DIR" ]; then
+		for _f in "$WG_NOIPV6_STATE_DIR"/*.dev; do
+			[ -f "$_f" ] || continue
+			_dev="$(head -n1 "$_f" 2>/dev/null)"
+			wg_iface_is_valid "$_dev" && wg_clear_dev "$_dev"
+			rm -f "$_f"
+		done
+	fi
+	# Sweep any remaining drop-ins by glob (covers the case where
+	# state files were lost but drop-ins linger on disk).
+	for _f in "$WG_NOIPV6_SYSCTL_DIR"/99-wg-noipv6-*.conf; do
+		[ -f "$_f" ] || continue
+		rm -f "$_f"
+	done
+	for _f in "$WG_NOIPV6_NFT_DIR"/99-wg-noipv6-*.nft; do
+		[ -f "$_f" ] || continue
+		rm -f "$_f"
+	done
+	if [ -d "$WG_NOIPV6_FW3_DIR" ]; then
+		for _f in "$WG_NOIPV6_FW3_DIR"/wg-noipv6-*.sh; do
+			[ -f "$_f" ] || continue
+			rm -f "$_f"
+		done
+	fi
+	# Drop any UCI firewall include sections we created.
+	for _i in $(uci -q show firewall 2>/dev/null \
+			| awk -F. '/^firewall\.wg_noipv6_/ {print $2}' \
+			| awk -F= '{print $1}' | sort -u); do
+		uci -q delete "firewall.${_i}" 2>/dev/null || true
+	done
+	uci -q commit firewall
+	/etc/init.d/firewall reload >/dev/null 2>&1 || true
+	sysctl --system >/dev/null 2>&1 || true
+}

--- a/gl-sdk4-wireguard-ipv4-only/files/usr/lib/wg-noipv6/functions.sh
+++ b/gl-sdk4-wireguard-ipv4-only/files/usr/lib/wg-noipv6/functions.sh
@@ -1,20 +1,6 @@
 #!/bin/sh
 # shellcheck shell=ash
-#
-# /usr/lib/wg-noipv6/functions.sh
-#
-# Shared POSIX-sh helpers for the gl-sdk4-wireguard-ipv4-only package.
-#
-# Sourced by:
-#   /usr/sbin/wg-noipv6
-#   /etc/init.d/wg-noipv6
-#   /etc/hotplug.d/iface/99-wg-noipv6
-#   /etc/hotplug.d/net/99-wg-noipv6
-#
-# Layout: behaviour mirrors the upstream reference script
-# (configure-wireguard-ipv4-only.sh by Blackout Secure) but is
-# wired into GL.iNet's wireguard_server UCI config so the GUI
-# `enable_ipv6` toggle drives state directly.
+# Shared helpers for gl-sdk4-wireguard-ipv4-only.
 
 WG_NOIPV6_TAG="wg-noipv6"
 WG_NOIPV6_SYSCTL_DIR="/etc/sysctl.d"
@@ -23,13 +9,10 @@ WG_NOIPV6_FW3_DIR="/etc/wg-noipv6/fw3"
 WG_NOIPV6_STATE_DIR="/var/run/wg-noipv6"
 WG_NOIPV6_DEFAULT_DEV="wgserver"
 
-_wg_log() {
-	logger -t "$WG_NOIPV6_TAG" "$*" 2>/dev/null || true
-}
+_wg_log()  { logger -t "$WG_NOIPV6_TAG" -p daemon.notice "$*" 2>/dev/null || true; }
+_wg_warn() { logger -t "$WG_NOIPV6_TAG" -p daemon.warn   "$*" 2>/dev/null || true; }
 
-# Validate an interface name before interpolating it into firewall /
-# sysctl drop-ins. Reject anything that isn't a normal Linux netdev
-# name to avoid command injection through user-controlled UCI values.
+# Reject names that aren't safe to interpolate into root-owned drop-ins.
 wg_iface_is_valid() {
 	case "$1" in
 		''|*[!A-Za-z0-9_-]*|[!A-Za-z]*) return 1 ;;
@@ -37,7 +20,6 @@ wg_iface_is_valid() {
 	return 0
 }
 
-# Echo "fw4" if nftables/fw4 is available, otherwise "fw3".
 wg_detect_fw_backend() {
 	if [ -x /sbin/fw4 ] || command -v nft >/dev/null 2>&1; then
 		printf 'fw4\n'
@@ -46,42 +28,29 @@ wg_detect_fw_backend() {
 	fi
 }
 
-# List wireguard_server "servers" sections (GL.iNet layout).
-wg_list_glinet_servers() {
-	[ -f /etc/config/wireguard_server ] || return 0
-	uci -q show wireguard_server 2>/dev/null | awk -F= '
-		/=.?servers.?$/ {
+wg_list_sections() {
+	[ -f "/etc/config/$1" ] || return 0
+	uci -q show "$1" 2>/dev/null | awk -F= -v t="$2" '
+		$2 == t {
 			n = split($1, parts, ".")
-			if (n >= 2) print parts[2]
+			if (n == 2) print parts[2]
 		}
 	' | sort -u
 }
 
-# List all peers sections in /etc/config/wireguard_server.
-wg_list_glinet_peers() {
-	[ -f /etc/config/wireguard_server ] || return 0
-	uci -q show wireguard_server 2>/dev/null | awk -F= '
-		/=.?peers.?$/ {
-			n = split($1, parts, ".")
-			if (n >= 2) print parts[2]
-		}
-	'
-}
+wg_list_glinet_servers() { wg_list_sections wireguard_server servers; }
+wg_list_glinet_peers()   { wg_list_sections wireguard_server peers; }
 
-# List netifd-managed wireguard interfaces.
 wg_list_netifd_ifaces() {
 	[ -f /etc/config/network ] || return 0
 	uci -q show network 2>/dev/null | awk -F= '
 		/\.proto=.?wireguard.?$/ {
 			n = split($1, parts, ".")
-			if (n >= 2) print parts[2]
+			if (n == 2) print parts[2]
 		}
 	' | sort -u
 }
 
-# Echo the kernel device name for the given GL.iNet server section.
-# Falls back to $WG_NOIPV6_DEFAULT_DEV ("wgserver"), which is what
-# GL.iNet firmware uses by default.
 wg_glinet_kernel_dev() {
 	_srv="$1"
 	[ -n "$_srv" ] || { printf '%s\n' "$WG_NOIPV6_DEFAULT_DEV"; return; }
@@ -91,7 +60,6 @@ wg_glinet_kernel_dev() {
 	printf '%s\n' "$_d"
 }
 
-# Echo the kernel device name for the given netifd wireguard section.
 wg_netifd_kernel_dev() {
 	_iface="$1"
 	[ -n "$_iface" ] || return 0
@@ -100,34 +68,24 @@ wg_netifd_kernel_dev() {
 	printf '%s\n' "$_d"
 }
 
-# Read the per-server enable_ipv6 toggle. Defaults to 1 (IPv6 allowed)
-# so existing GL.iNet behaviour is preserved when the option is unset.
-wg_glinet_enable_ipv6() {
-	_srv="$1"
-	_v="$(uci -q get "wireguard_server.${_srv}.enable_ipv6" 2>/dev/null)"
-	case "$_v" in
-		0|no|off|false|disabled) printf '0\n' ;;
-		*) printf '1\n' ;;
+# Resolve the global IPv6 state surfaced by the GL.iNet /#/ipv6 page.
+# Layered fallback so the package works across firmware revisions.
+# Echoes '1' when enabled, '0' when disabled.
+wg_global_ipv6_enabled() {
+	case "$(uci -q get glconfig.general.enable_ipv6 2>/dev/null)" in
+		0|no|off|false|disabled) printf '0\n'; return ;;
+		1|yes|on|true|enabled)   printf '1\n'; return ;;
 	esac
+	[ "$(uci -q get network.wan6.disabled 2>/dev/null)" = "1" ] && { printf '0\n'; return; }
+	[ "$(uci -q get network.wan6.proto    2>/dev/null)" = "none" ] && { printf '0\n'; return; }
+	[ "$(uci -q get network.wan6.auto     2>/dev/null)" = "0" ] && { printf '0\n'; return; }
+	printf '1\n'
 }
 
-# Read per-section enable_ipv6 toggle for netifd wireguard ifaces.
-# Same defaulting rule as the glinet version.
-wg_netifd_enable_ipv6() {
-	_iface="$1"
-	_v="$(uci -q get "network.${_iface}.enable_ipv6" 2>/dev/null)"
-	case "$_v" in
-		0|no|off|false|disabled) printf '0\n' ;;
-		*) printf '1\n' ;;
-	esac
-}
-
-# Strip non-link-local IPv6 addresses from a live kernel device.
-# Echoes the count of addresses removed.
+# Strip non-link-local IPv6 from a live device. Echoes the count removed.
 wg_strip_live_ipv6() {
 	_dev="$1"
-	[ -n "$_dev" ] || { printf '0\n'; return 0; }
-	[ -d "/sys/class/net/$_dev" ] || { printf '0\n'; return 0; }
+	[ -n "$_dev" ] && [ -d "/sys/class/net/$_dev" ] || { printf '0\n'; return 0; }
 	_n=0
 	for _a in $(ip -6 addr show dev "$_dev" 2>/dev/null \
 			| awk '/inet6/ && $2 !~ /^fe80/ {print $2}'); do
@@ -136,9 +94,7 @@ wg_strip_live_ipv6() {
 	printf '%s\n' "$_n"
 }
 
-# Drop ":"-bearing entries from a comma-separated list. Used for the
-# GL.iNet peer client_ip / allowed_ips fields which carry both the
-# IPv4 and IPv6 sides as a single CSV string.
+# Drop ":"-bearing entries from a comma-separated list.
 wg_strip_v6_from_csv() {
 	printf '%s' "$1" | awk -v RS=',' '{
 		gsub(/^[ \t]+|[ \t]+$/, "", $0)
@@ -149,7 +105,6 @@ wg_strip_v6_from_csv() {
 	} END { print out }'
 }
 
-# Strip IPv6 entries from netifd network.<iface>.addresses list.
 wg_strip_netifd_ipv6_addrs() {
 	_iface="$1"
 	_addrs=""
@@ -162,22 +117,18 @@ wg_strip_netifd_ipv6_addrs() {
 	done
 }
 
-# Reconcile the live kernel WG peer state to drop IPv6 entries from
-# each peer's AllowedIPs. Required because wireguard_server may not
-# re-push peer programming after a UCI rewrite + restart -- existing
-# sessions keep their old AllowedIPs in the kernel until the peer
-# re-handshakes. Echoes the count of peers updated.
+# Re-program live kernel peers whose AllowedIPs still carry IPv6.
+# Required because wireguard_server may not re-push peer programming
+# after a UCI rewrite + restart. Echoes the count of peers updated.
 wg_reconcile_kernel_peers_ipv4() {
 	_dev="$1"
-	[ -n "$_dev" ] || { printf '0\n'; return 0; }
-	[ -d "/sys/class/net/$_dev" ] || { printf '0\n'; return 0; }
+	[ -n "$_dev" ] && [ -d "/sys/class/net/$_dev" ] || { printf '0\n'; return 0; }
 	command -v wg >/dev/null 2>&1 || { printf '0\n'; return 0; }
 	_tmp="/tmp/.wg_noipv6_peers.$$"
 	wg show "$_dev" allowed-ips >"$_tmp" 2>/dev/null || {
 		rm -f "$_tmp"; printf '0\n'; return 0
 	}
 	_updated=0
-	# Each line: "<pubkey>\t<ip1> <ip2> ..." or "<pubkey>\t(none)"
 	while IFS="$(printf '\t')" read -r _pub _ips; do
 		[ -n "$_pub" ] || continue
 		case "$_ips" in '(none)'|'') continue ;; esac
@@ -192,9 +143,9 @@ wg_reconcile_kernel_peers_ipv4() {
 		done
 		[ "$_had_v6" -eq 1 ] || continue
 		if [ -z "$_new" ]; then
-			# Peer is IPv6-only -- refuse to clear so we don't
-			# accidentally unroute the peer entirely.
-			_wg_log "kernel peer ${_pub} has only IPv6 allowed-ips; not modifying"
+			# Refuse to clear: stripping would leave the peer with no
+			# AllowedIPs and unroute it entirely.
+			_wg_warn "kernel peer ${_pub} on ${_dev} is IPv6-only; not modifying"
 			continue
 		fi
 		if wg set "$_dev" peer "$_pub" allowed-ips "$_new" 2>/dev/null; then
@@ -205,17 +156,13 @@ wg_reconcile_kernel_peers_ipv4() {
 	printf '%s\n' "$_updated"
 }
 
-# Pin a single GL.iNet wireguard_server section to IPv4-only:
-#  - clear address_v6 on the server section
-#  - strip ":"-bearing entries from each peer's client_ip / allowed_ips
-# Returns 0 if anything changed, 1 otherwise.
+# Pin a GL.iNet server section (and every peer) to IPv4-only in UCI.
 wg_pin_glinet_ipv4() {
 	_srv="$1"
 	[ -n "$_srv" ] || return 1
 	[ -n "$(uci -q get "wireguard_server.${_srv}")" ] || return 1
 	_changed=0
 
-	# 1) server section: clear address_v6
 	_v6srv="$(uci -q get "wireguard_server.${_srv}.address_v6" 2>/dev/null)"
 	if [ -n "$_v6srv" ]; then
 		uci -q delete "wireguard_server.${_srv}.address_v6"
@@ -223,21 +170,19 @@ wg_pin_glinet_ipv4() {
 		_wg_log "cleared wireguard_server.${_srv}.address_v6 (was: $_v6srv)"
 	fi
 
-	# 2) peers: strip ":"-bearing entries from CSV options
 	for _p in $(wg_list_glinet_peers); do
 		for _key in client_ip allowed_ips; do
 			_cur="$(uci -q get "wireguard_server.${_p}.${_key}" 2>/dev/null)"
 			[ -n "$_cur" ] || continue
 			_new="$(wg_strip_v6_from_csv "$_cur")"
-			if [ "$_cur" != "$_new" ]; then
-				if [ -n "$_new" ]; then
-					uci -q set "wireguard_server.${_p}.${_key}=$_new"
-				else
-					uci -q delete "wireguard_server.${_p}.${_key}"
-				fi
-				_changed=1
-				_wg_log "wireguard_server.${_p}.${_key}: stripped IPv6 (now: ${_new:-<unset>})"
+			[ "$_cur" = "$_new" ] && continue
+			if [ -n "$_new" ]; then
+				uci -q set "wireguard_server.${_p}.${_key}=$_new"
+			else
+				uci -q delete "wireguard_server.${_p}.${_key}"
 			fi
+			_changed=1
+			_wg_log "wireguard_server.${_p}.${_key}: stripped IPv6 (now: ${_new:-<unset>})"
 		done
 	done
 
@@ -245,9 +190,6 @@ wg_pin_glinet_ipv4() {
 	return 0
 }
 
-# Pin a single netifd wireguard section to IPv4-only:
-#  - set network.<iface>.ipv6=0
-#  - strip IPv6 entries from network.<iface>.addresses
 wg_pin_netifd_ipv4() {
 	_iface="$1"
 	[ -n "$_iface" ] || return 1
@@ -270,8 +212,6 @@ wg_pin_netifd_ipv4() {
 	return 0
 }
 
-# Restore the netifd defaults for a section: drop the ipv6=0 marker
-# we set; we leave addresses alone (the GUI will re-issue them).
 wg_unpin_netifd_ipv4() {
 	_iface="$1"
 	[ -n "$_iface" ] || return 1
@@ -281,8 +221,6 @@ wg_unpin_netifd_ipv4() {
 	fi
 }
 
-# Write the per-iface sysctl drop-in that pins disable_ipv6=1 on the
-# WG kernel device. Idempotent.
 wg_apply_sysctl() {
 	_dev="$1"
 	wg_iface_is_valid "$_dev" || return 1
@@ -304,8 +242,6 @@ wg_remove_sysctl() {
 		&& echo 0 > "/proc/sys/net/ipv6/conf/$_dev/disable_ipv6" 2>/dev/null || true
 }
 
-# Install the fw4 nftables drop-in that blocks IPv6 traffic on the
-# WG kernel device.
 wg_apply_firewall_fw4() {
 	_dev="$1"
 	wg_iface_is_valid "$_dev" || return 1
@@ -338,7 +274,6 @@ wg_remove_firewall_fw4() {
 	/etc/init.d/firewall reload >/dev/null 2>&1 || true
 }
 
-# Install the fw3 firewall include + ip6tables drop rules.
 wg_apply_firewall_fw3() {
 	_dev="$1"
 	wg_iface_is_valid "$_dev" || return 1
@@ -386,7 +321,6 @@ wg_remove_firewall_fw3() {
 	/etc/init.d/firewall reload >/dev/null 2>&1 || true
 }
 
-# Backend dispatcher.
 wg_apply_firewall() {
 	case "$(wg_detect_fw_backend)" in
 		fw4) wg_apply_firewall_fw4 "$1" ;;
@@ -401,48 +335,45 @@ wg_remove_firewall() {
 	esac
 }
 
-# Apply IPv4-only enforcement for one GL.iNet server section.
-# Expects a validated kernel device name; safe to call repeatedly.
+# Host-side enforcement on a kernel device. Idempotent.
+wg_apply_dev_hostside() {
+	_dev="$1"
+	wg_iface_is_valid "$_dev" || return 1
+	wg_apply_sysctl "$_dev"
+	wg_apply_firewall "$_dev"
+	_n="$(wg_strip_live_ipv6 "$_dev")"
+	[ "$_n" -gt 0 ] && _wg_log "removed $_n IPv6 address(es) from $_dev"
+	_p="$(wg_reconcile_kernel_peers_ipv4 "$_dev")"
+	[ "$_p" -gt 0 ] && _wg_log "reconciled $_p kernel peer(s) on $_dev to IPv4-only"
+	return 0
+}
+
 wg_apply_glinet() {
 	_srv="$1"
 	_dev="$2"
 	wg_iface_is_valid "$_dev" || {
-		_wg_log "refusing to act on invalid iface name '$_dev' for $_srv"
+		_wg_warn "refusing to act on invalid iface name '$_dev' for $_srv"
 		return 1
 	}
 	wg_pin_glinet_ipv4 "$_srv"
-	wg_apply_sysctl "$_dev"
-	wg_apply_firewall "$_dev"
-	_n="$(wg_strip_live_ipv6 "$_dev")"
-	[ "$_n" -gt 0 ] && _wg_log "removed $_n IPv6 address(es) from $_dev"
-	_p="$(wg_reconcile_kernel_peers_ipv4 "$_dev")"
-	[ "$_p" -gt 0 ] && _wg_log "reconciled $_p kernel peer(s) on $_dev to IPv4-only"
+	wg_apply_dev_hostside "$_dev"
 	mkdir -p "$WG_NOIPV6_STATE_DIR"
 	printf '%s\n' "$_dev" > "${WG_NOIPV6_STATE_DIR}/glinet-${_srv}.dev"
-	return 0
 }
 
-# Apply IPv4-only enforcement for one netifd wireguard interface.
 wg_apply_netifd() {
 	_iface="$1"
 	_dev="$2"
 	wg_iface_is_valid "$_dev" || {
-		_wg_log "refusing to act on invalid iface name '$_dev' for $_iface"
+		_wg_warn "refusing to act on invalid iface name '$_dev' for $_iface"
 		return 1
 	}
 	wg_pin_netifd_ipv4 "$_iface"
-	wg_apply_sysctl "$_dev"
-	wg_apply_firewall "$_dev"
-	_n="$(wg_strip_live_ipv6 "$_dev")"
-	[ "$_n" -gt 0 ] && _wg_log "removed $_n IPv6 address(es) from $_dev"
-	_p="$(wg_reconcile_kernel_peers_ipv4 "$_dev")"
-	[ "$_p" -gt 0 ] && _wg_log "reconciled $_p kernel peer(s) on $_dev to IPv4-only"
+	wg_apply_dev_hostside "$_dev"
 	mkdir -p "$WG_NOIPV6_STATE_DIR"
 	printf '%s\n' "$_dev" > "${WG_NOIPV6_STATE_DIR}/netifd-${_iface}.dev"
-	return 0
 }
 
-# Remove enforcement for a previously-pinned device.
 wg_clear_dev() {
 	_dev="$1"
 	wg_iface_is_valid "$_dev" || return 1
@@ -450,53 +381,49 @@ wg_clear_dev() {
 	wg_remove_firewall "$_dev"
 }
 
-# Walk every wireguard server section and apply or clear based on the
-# per-section enable_ipv6 toggle. This is the entry point used by
-# `/etc/init.d/wg-noipv6 reload`, the uci-defaults bootstrap, the RPC
-# adapter and the iface hotplug script.
+# Tear down enforcement using the on-disk state file as the source of
+# truth for the previous device name (in case it has changed under us).
+_wg_teardown_section() {
+	_state="$1"
+	_dev="$2"
+	if [ -f "$_state" ]; then
+		_old="$(head -n1 "$_state" 2>/dev/null)"
+		wg_iface_is_valid "$_old" && wg_clear_dev "$_old"
+		rm -f "$_state"
+	fi
+	wg_iface_is_valid "$_dev" && wg_clear_dev "$_dev"
+}
+
+# Reconcile every WG server / interface against the global IPv6 state.
 wg_sync_all() {
 	mkdir -p "$WG_NOIPV6_STATE_DIR"
 
-	# GL.iNet wireguard_server layout
+	_off=0
+	[ "$(wg_global_ipv6_enabled)" = "0" ] && _off=1
+
 	for _srv in $(wg_list_glinet_servers); do
 		_dev="$(wg_glinet_kernel_dev "$_srv")"
 		wg_iface_is_valid "$_dev" || continue
-		_state="${WG_NOIPV6_STATE_DIR}/glinet-${_srv}.dev"
-		if [ "$(wg_glinet_enable_ipv6 "$_srv")" = "0" ]; then
+		if [ "$_off" -eq 1 ]; then
 			wg_apply_glinet "$_srv" "$_dev"
 		else
-			# enabled (or unset/default): tear down anything we
-			# previously installed for this server's last device.
-			if [ -f "$_state" ]; then
-				_old="$(head -n1 "$_state" 2>/dev/null)"
-				wg_iface_is_valid "$_old" && wg_clear_dev "$_old"
-				rm -f "$_state"
-			fi
-			wg_iface_is_valid "$_dev" && wg_clear_dev "$_dev"
+			_wg_teardown_section "${WG_NOIPV6_STATE_DIR}/glinet-${_srv}.dev" "$_dev"
 		fi
 	done
 
-	# netifd layout (proto=wireguard)
 	for _iface in $(wg_list_netifd_ifaces); do
 		_dev="$(wg_netifd_kernel_dev "$_iface")"
 		wg_iface_is_valid "$_dev" || continue
-		_state="${WG_NOIPV6_STATE_DIR}/netifd-${_iface}.dev"
-		if [ "$(wg_netifd_enable_ipv6 "$_iface")" = "0" ]; then
+		if [ "$_off" -eq 1 ]; then
 			wg_apply_netifd "$_iface" "$_dev"
 		else
-			if [ -f "$_state" ]; then
-				_old="$(head -n1 "$_state" 2>/dev/null)"
-				wg_iface_is_valid "$_old" && wg_clear_dev "$_old"
-				rm -f "$_state"
-			fi
 			wg_unpin_netifd_ipv4 "$_iface"
-			wg_iface_is_valid "$_dev" && wg_clear_dev "$_dev"
+			_wg_teardown_section "${WG_NOIPV6_STATE_DIR}/netifd-${_iface}.dev" "$_dev"
 		fi
 	done
 }
 
-# Used at package removal time: drop every drop-in we might have
-# installed and restore default behaviour.
+# Remove every drop-in this package may have installed (used by prerm).
 wg_clear_all() {
 	if [ -d "$WG_NOIPV6_STATE_DIR" ]; then
 		for _f in "$WG_NOIPV6_STATE_DIR"/*.dev; do
@@ -506,29 +433,18 @@ wg_clear_all() {
 			rm -f "$_f"
 		done
 	fi
-	# Sweep any remaining drop-ins by glob (covers the case where
-	# state files were lost but drop-ins linger on disk).
-	for _f in "$WG_NOIPV6_SYSCTL_DIR"/99-wg-noipv6-*.conf; do
-		[ -f "$_f" ] || continue
-		rm -f "$_f"
+	for _f in "$WG_NOIPV6_SYSCTL_DIR"/99-wg-noipv6-*.conf \
+	          "$WG_NOIPV6_NFT_DIR"/99-wg-noipv6-*.nft \
+	          "$WG_NOIPV6_FW3_DIR"/wg-noipv6-*.sh; do
+		[ -f "$_f" ] && rm -f "$_f"
 	done
-	for _f in "$WG_NOIPV6_NFT_DIR"/99-wg-noipv6-*.nft; do
-		[ -f "$_f" ] || continue
-		rm -f "$_f"
-	done
-	if [ -d "$WG_NOIPV6_FW3_DIR" ]; then
-		for _f in "$WG_NOIPV6_FW3_DIR"/wg-noipv6-*.sh; do
-			[ -f "$_f" ] || continue
-			rm -f "$_f"
-		done
-	fi
-	# Drop any UCI firewall include sections we created.
+	_changed=0
 	for _i in $(uci -q show firewall 2>/dev/null \
-			| awk -F. '/^firewall\.wg_noipv6_/ {print $2}' \
-			| awk -F= '{print $1}' | sort -u); do
-		uci -q delete "firewall.${_i}" 2>/dev/null || true
+			| awk -F. '/^firewall\.wg_noipv6_/ { sub(/=.*/, "", $2); print $2 }' \
+			| sort -u); do
+		uci -q delete "firewall.${_i}" 2>/dev/null && _changed=1
 	done
-	uci -q commit firewall
+	[ "$_changed" -eq 1 ] && uci -q commit firewall
 	/etc/init.d/firewall reload >/dev/null 2>&1 || true
 	sysctl --system >/dev/null 2>&1 || true
 }

--- a/gl-sdk4-wireguard-ipv4-only/files/usr/lib/wg-noipv6/functions.sh
+++ b/gl-sdk4-wireguard-ipv4-only/files/usr/lib/wg-noipv6/functions.sh
@@ -622,11 +622,14 @@ wg_clear_dev() {
 _wg_teardown_section() {
 	_state="$1"
 	_dev="$2"
+	_old=""
 	if [ -f "$_state" ]; then
 		_old="$(head -n1 "$_state" 2>/dev/null)"
 		wg_iface_is_valid "$_old" && wg_clear_dev "$_old"
 		rm -f "$_state"
 	fi
+	# Avoid clearing the same dev twice when the state file matched.
+	[ "$_old" = "$_dev" ] && return 0
 	wg_iface_is_valid "$_dev" && wg_clear_dev "$_dev"
 }
 

--- a/gl-sdk4-wireguard-ipv4-only/files/usr/lib/wg-noipv6/functions.sh
+++ b/gl-sdk4-wireguard-ipv4-only/files/usr/lib/wg-noipv6/functions.sh
@@ -7,10 +7,27 @@ WG_NOIPV6_SYSCTL_DIR="/etc/sysctl.d"
 WG_NOIPV6_NFT_DIR="/etc/nftables.d"
 WG_NOIPV6_FW3_DIR="/etc/wg-noipv6/fw3"
 WG_NOIPV6_STATE_DIR="/var/run/wg-noipv6"
+WG_NOIPV6_BACKUP_DIR="/etc/wg-noipv6/backup"
 WG_NOIPV6_DEFAULT_DEV="wgserver"
 
-_wg_log()  { logger -t "$WG_NOIPV6_TAG" -p daemon.notice "$*" 2>/dev/null || true; }
-_wg_warn() { logger -t "$WG_NOIPV6_TAG" -p daemon.warn   "$*" 2>/dev/null || true; }
+# All logging funnels through here so the tag and error swallowing live
+# in exactly one place.
+_wg_logger() {
+	_prio="$1"; shift
+	logger -t "$WG_NOIPV6_TAG" -p "$_prio" "$*" 2>/dev/null || true
+}
+
+_wg_log()  { _wg_logger daemon.notice "$@"; }
+_wg_warn() { _wg_logger daemon.warn   "$@"; }
+
+# Headline message: always to syslog; also to stderr when stderr is a TTY
+# and WG_NOIPV6_QUIET is unset (hooks set it to 1 to stay quiet).
+_wg_say() {
+	_wg_logger daemon.notice "$@"
+	[ "${WG_NOIPV6_QUIET:-0}" = "1" ] && return 0
+	[ -t 2 ] || return 0
+	printf '%s: %s\n' "$WG_NOIPV6_TAG" "$*" >&2
+}
 
 # Reject names that aren't safe to interpolate into root-owned drop-ins.
 wg_iface_is_valid() {
@@ -43,10 +60,13 @@ wg_list_glinet_peers()   { wg_list_sections wireguard_server peers; }
 
 wg_list_netifd_ifaces() {
 	[ -f /etc/config/network ] || return 0
+	# UCI keys for the proto option look like 'network.<iface>.proto=...',
+	# i.e. they always split into 3 dot-separated parts; the iface name
+	# we want is parts[2].
 	uci -q show network 2>/dev/null | awk -F= '
 		/\.proto=.?wireguard.?$/ {
 			n = split($1, parts, ".")
-			if (n == 2) print parts[2]
+			if (n == 3) print parts[2]
 		}
 	' | sort -u
 }
@@ -117,14 +137,223 @@ wg_strip_netifd_ipv6_addrs() {
 	done
 }
 
+# ---------------------------------------------------------------------------
+# Snapshot / restore
+# ---------------------------------------------------------------------------
+# The disable path strips IPv6 fields from UCI. Originals are saved under
+# WG_NOIPV6_BACKUP_DIR (mode 0700, files 0600) before stripping and replayed
+# when global IPv6 returns. Format: KEY=VALUE per line, KEY contains no '='.
+
+_wg_snap_path()        { printf '%s/%s-%s.snap\n' "$WG_NOIPV6_BACKUP_DIR" "$1" "$2"; }
+_wg_snap_path_glinet() { _wg_snap_path glinet "$1"; }
+_wg_snap_path_netifd() { _wg_snap_path netifd "$1"; }
+
+# Prepare backup dir + a 0600 temp file for $1; echo the temp path. Caller
+# writes to that path then renames over $1.
+_wg_snap_open() {
+	mkdir -p "$WG_NOIPV6_BACKUP_DIR"
+	chmod 0700 "$WG_NOIPV6_BACKUP_DIR" 2>/dev/null || true
+	_t="${1}.tmp"
+	: > "$_t"
+	chmod 0600 "$_t" 2>/dev/null || true
+	printf '%s\n' "$_t"
+}
+
+# Count snapshot files of a given source ('glinet' or 'netifd').
+_wg_count_snaps() {
+	_n=0
+	[ -d "$WG_NOIPV6_BACKUP_DIR" ] || { printf '0\n'; return 0; }
+	for _f in "$WG_NOIPV6_BACKUP_DIR"/"$1"-*.snap; do
+		[ -f "$_f" ] && _n=$((_n+1))
+	done
+	printf '%s\n' "$_n"
+}
+
+# Best-effort init.d reloads. Safe no-op when the script is absent.
+_wg_kick_wgserver() {
+	[ -x /etc/init.d/wireguard_server ] && \
+		/etc/init.d/wireguard_server reload >/dev/null 2>&1 || true
+}
+_wg_kick_network() {
+	[ -x /etc/init.d/network ] && \
+		/etc/init.d/network reload >/dev/null 2>&1 || true
+}
+_wg_kick_firewall() {
+	[ -x /etc/init.d/firewall ] && \
+		/etc/init.d/firewall reload >/dev/null 2>&1 || true
+}
+
+# Save the fields wg_pin_glinet_ipv4 is about to strip. Refuses to overwrite
+# an existing snapshot so a re-sync while still disabled doesn't capture the
+# already-stripped state.
+wg_snapshot_glinet() {
+	_srv="$1"
+	[ -n "$_srv" ] || return 1
+	_path="$(_wg_snap_path_glinet "$_srv")"
+	[ -f "$_path" ] && return 0
+	_tmp="$(_wg_snap_open "$_path")"
+
+	_v6srv="$(uci -q get "wireguard_server.${_srv}.address_v6" 2>/dev/null)"
+	[ -n "$_v6srv" ] && printf 'server.address_v6=%s\n' "$_v6srv" >> "$_tmp"
+
+	# Peer sections are global to wireguard_server, not per-server.
+	for _p in $(wg_list_glinet_peers); do
+		for _key in client_ip allowed_ips; do
+			_cur="$(uci -q get "wireguard_server.${_p}.${_key}" 2>/dev/null)"
+			[ -n "$_cur" ] || continue
+			case "$_cur" in *:*) ;; *) continue ;; esac
+			printf 'peer.%s.%s=%s\n' "$_p" "$_key" "$_cur" >> "$_tmp"
+		done
+	done
+
+	mv "$_tmp" "$_path"
+	return 0
+}
+
+# Restore a glinet snapshot, then delete it. No-op if absent. Triggers a
+# wireguard_server reload only when something actually changed.
+wg_restore_glinet() {
+	_srv="$1"
+	[ -n "$_srv" ] || return 1
+	_path="$(_wg_snap_path_glinet "$_srv")"
+	[ -f "$_path" ] || return 0
+	_changed=0
+
+	# Read line-by-line; KEY is everything up to the first '=', VALUE is the
+	# rest (so '=' inside the value is preserved).
+	while IFS= read -r _line || [ -n "$_line" ]; do
+		[ -n "$_line" ] || continue
+		_k="${_line%%=*}"
+		_v="${_line#*=}"
+		case "$_k" in
+			server.address_v6)
+				[ -n "$(uci -q get "wireguard_server.${_srv}")" ] || continue
+				_cur="$(uci -q get "wireguard_server.${_srv}.address_v6" 2>/dev/null)"
+				[ "$_cur" = "$_v" ] && continue
+				uci -q set "wireguard_server.${_srv}.address_v6=$_v"
+				_changed=1
+				_wg_log "restored wireguard_server.${_srv}.address_v6 (= $_v)"
+				;;
+			peer.*)
+				_rest="${_k#peer.}"
+				_peer="${_rest%%.*}"
+				_field="${_rest#*.}"
+				[ -n "$_peer" ] && [ -n "$_field" ] || continue
+				[ "$_peer" = "$_field" ] && continue
+				[ -n "$(uci -q get "wireguard_server.${_peer}")" ] || continue
+				_cur="$(uci -q get "wireguard_server.${_peer}.${_field}" 2>/dev/null)"
+				[ "$_cur" = "$_v" ] && continue
+				uci -q set "wireguard_server.${_peer}.${_field}=$_v"
+				_changed=1
+				_wg_log "restored wireguard_server.${_peer}.${_field} (= $_v)"
+				;;
+		esac
+	done < "$_path"
+
+	if [ "$_changed" -eq 1 ]; then
+		uci -q commit wireguard_server
+		_wg_kick_wgserver
+	fi
+	rm -f "$_path"
+	return 0
+}
+
+wg_snapshot_netifd() {
+	_iface="$1"
+	[ -n "$_iface" ] || return 1
+	_path="$(_wg_snap_path_netifd "$_iface")"
+	[ -f "$_path" ] && return 0
+	_tmp="$(_wg_snap_open "$_path")"
+
+	# Always record the pre-strip ipv6 setting (empty value = was unset).
+	_ipv6cur="$(uci -q get "network.${_iface}.ipv6" 2>/dev/null)"
+	printf 'ipv6=%s\n' "$_ipv6cur" >> "$_tmp"
+
+	for _a in $(uci -q get "network.${_iface}.addresses" 2>/dev/null); do
+		case "$_a" in *:*) printf 'address=%s\n' "$_a" >> "$_tmp" ;; esac
+	done
+
+	mv "$_tmp" "$_path"
+	return 0
+}
+
+wg_restore_netifd() {
+	_iface="$1"
+	[ -n "$_iface" ] || return 1
+	_path="$(_wg_snap_path_netifd "$_iface")"
+	[ -f "$_path" ] || return 0
+	[ -n "$(uci -q get "network.${_iface}")" ] || { rm -f "$_path"; return 0; }
+
+	_changed=0
+	_saw_ipv6=0
+	_saw_ipv6_val=""
+	_saw_addrs=""
+	while IFS= read -r _line || [ -n "$_line" ]; do
+		[ -n "$_line" ] || continue
+		_k="${_line%%=*}"
+		_v="${_line#*=}"
+		case "$_k" in
+			ipv6)    _saw_ipv6=1; _saw_ipv6_val="$_v" ;;
+			address) _saw_addrs="$_saw_addrs $_v" ;;
+		esac
+	done < "$_path"
+
+	if [ "$_saw_ipv6" -eq 1 ]; then
+		if [ -z "$_saw_ipv6_val" ]; then
+			if [ -n "$(uci -q get "network.${_iface}.ipv6")" ]; then
+				uci -q delete "network.${_iface}.ipv6" 2>/dev/null && _changed=1
+			fi
+		else
+			_cur="$(uci -q get "network.${_iface}.ipv6")"
+			if [ "$_cur" != "$_saw_ipv6_val" ]; then
+				uci -q set "network.${_iface}.ipv6=$_saw_ipv6_val"
+				_changed=1
+			fi
+		fi
+	fi
+
+	for _a in $_saw_addrs; do
+		_present=0
+		for _ex in $(uci -q get "network.${_iface}.addresses" 2>/dev/null); do
+			[ "$_ex" = "$_a" ] && { _present=1; break; }
+		done
+		[ "$_present" -eq 1 ] && continue
+		uci -q add_list "network.${_iface}.addresses=$_a" 2>/dev/null || continue
+		_changed=1
+		_wg_log "restored IPv6 address ${_a} on network.${_iface}"
+	done
+
+	[ "$_changed" -eq 1 ] && uci -q commit network
+	rm -f "$_path"
+	return 0
+}
+
+# Restore every snapshot we hold, regardless of source. Used by
+# `wg-noipv6 clear-all` so removing the package never strands the user with
+# stripped configs. Only restores UCI -- network reload is the caller's job.
+wg_restore_all() {
+	[ -d "$WG_NOIPV6_BACKUP_DIR" ] || return 0
+	for _f in "$WG_NOIPV6_BACKUP_DIR"/glinet-*.snap; do
+		[ -f "$_f" ] || continue
+		_n="${_f##*/glinet-}"; _n="${_n%.snap}"
+		[ -n "$_n" ] && wg_restore_glinet "$_n"
+	done
+	for _f in "$WG_NOIPV6_BACKUP_DIR"/netifd-*.snap; do
+		[ -f "$_f" ] || continue
+		_n="${_f##*/netifd-}"; _n="${_n%.snap}"
+		[ -n "$_n" ] && wg_restore_netifd "$_n"
+	done
+}
+
 # Re-program live kernel peers whose AllowedIPs still carry IPv6.
-# Required because wireguard_server may not re-push peer programming
-# after a UCI rewrite + restart. Echoes the count of peers updated.
+# wireguard_server may not re-push peer programming after a UCI rewrite +
+# restart. Echoes the count of peers updated.
 wg_reconcile_kernel_peers_ipv4() {
 	_dev="$1"
 	[ -n "$_dev" ] && [ -d "/sys/class/net/$_dev" ] || { printf '0\n'; return 0; }
 	command -v wg >/dev/null 2>&1 || { printf '0\n'; return 0; }
-	_tmp="/tmp/.wg_noipv6_peers.$$"
+	_tmp="$(mktemp /tmp/wg-noipv6-peers.XXXXXX 2>/dev/null)" \
+		|| _tmp="/tmp/.wg_noipv6_peers.$$"
 	wg show "$_dev" allowed-ips >"$_tmp" 2>/dev/null || {
 		rm -f "$_tmp"; printf '0\n'; return 0
 	}
@@ -143,8 +372,7 @@ wg_reconcile_kernel_peers_ipv4() {
 		done
 		[ "$_had_v6" -eq 1 ] || continue
 		if [ -z "$_new" ]; then
-			# Refuse to clear: stripping would leave the peer with no
-			# AllowedIPs and unroute it entirely.
+			# Refuse to clear: would unroute an IPv6-only peer entirely.
 			_wg_warn "kernel peer ${_pub} on ${_dev} is IPv6-only; not modifying"
 			continue
 		fi
@@ -263,7 +491,7 @@ chain wg_noipv6_output_${_dev} {
 	oifname "${_dev}" meta nfproto ipv6 drop
 }
 EOF
-	/etc/init.d/firewall reload >/dev/null 2>&1 || true
+	_wg_kick_firewall
 }
 
 wg_remove_firewall_fw4() {
@@ -271,7 +499,30 @@ wg_remove_firewall_fw4() {
 	wg_iface_is_valid "$_dev" || return 1
 	_path="${WG_NOIPV6_NFT_DIR}/99-wg-noipv6-${_dev}.nft"
 	[ -f "$_path" ] && rm -f "$_path"
-	/etc/init.d/firewall reload >/dev/null 2>&1 || true
+	_wg_kick_firewall
+}
+
+# fw3: emit/run the same four ip6tables rules. Action is '-I' or '-D'.
+# In emit mode -D probes get stderr silenced; -I lines stay loud so any insert
+# failure surfaces in the firewall log on reload.
+_wg_fw3_rules() {
+	_action="$1"; _dev="$2"; _emit="${3:-run}"
+	_redir=""
+	[ "$_action" = "-D" ] && _redir=" 2>/dev/null"
+	for _spec in \
+		"forwarding_rule -i" \
+		"forwarding_rule -o" \
+		"input_rule      -i" \
+		"output_rule     -o"; do
+		# shellcheck disable=SC2086 # intentional word-splitting
+		set -- $_spec
+		if [ "$_emit" = "emit" ]; then
+			printf 'ip6tables %s %s %s "$WG_DEV" -j DROP%s\n' \
+				"$_action" "$1" "$2" "$_redir"
+		else
+			ip6tables "$_action" "$1" "$2" "$_dev" -j DROP 2>/dev/null || true
+		fi
+	done
 }
 
 wg_apply_firewall_fw3() {
@@ -279,19 +530,13 @@ wg_apply_firewall_fw3() {
 	wg_iface_is_valid "$_dev" || return 1
 	mkdir -p "$WG_NOIPV6_FW3_DIR"
 	_path="${WG_NOIPV6_FW3_DIR}/wg-noipv6-${_dev}.sh"
-	cat > "$_path" <<EOF
-#!/bin/sh
-# Managed by gl-sdk4-wireguard-ipv4-only; do not edit by hand.
-WG_DEV="${_dev}"
-ip6tables -D forwarding_rule -i "\$WG_DEV" -j DROP 2>/dev/null
-ip6tables -D forwarding_rule -o "\$WG_DEV" -j DROP 2>/dev/null
-ip6tables -D input_rule      -i "\$WG_DEV" -j DROP 2>/dev/null
-ip6tables -D output_rule     -o "\$WG_DEV" -j DROP 2>/dev/null
-ip6tables -I forwarding_rule -i "\$WG_DEV" -j DROP
-ip6tables -I forwarding_rule -o "\$WG_DEV" -j DROP
-ip6tables -I input_rule      -i "\$WG_DEV" -j DROP
-ip6tables -I output_rule     -o "\$WG_DEV" -j DROP
-EOF
+	{
+		echo "#!/bin/sh"
+		echo "# Managed by gl-sdk4-wireguard-ipv4-only; do not edit by hand."
+		echo "WG_DEV=\"${_dev}\""
+		_wg_fw3_rules -D "$_dev" emit
+		_wg_fw3_rules -I "$_dev" emit
+	} > "$_path"
 	chmod 0755 "$_path"
 	_inc_name="wg_noipv6_${_dev}"
 	uci -q delete "firewall.${_inc_name}" 2>/dev/null || true
@@ -299,7 +544,7 @@ EOF
 	uci -q set "firewall.${_inc_name}.path=$_path"
 	uci -q set "firewall.${_inc_name}.reload=1"
 	uci -q commit firewall
-	/etc/init.d/firewall reload >/dev/null 2>&1 || true
+	_wg_kick_firewall
 }
 
 wg_remove_firewall_fw3() {
@@ -312,13 +557,8 @@ wg_remove_firewall_fw3() {
 		uci -q delete "firewall.${_inc_name}"
 		uci -q commit firewall
 	fi
-	if command -v ip6tables >/dev/null 2>&1; then
-		ip6tables -D forwarding_rule -i "$_dev" -j DROP 2>/dev/null || true
-		ip6tables -D forwarding_rule -o "$_dev" -j DROP 2>/dev/null || true
-		ip6tables -D input_rule      -i "$_dev" -j DROP 2>/dev/null || true
-		ip6tables -D output_rule     -o "$_dev" -j DROP 2>/dev/null || true
-	fi
-	/etc/init.d/firewall reload >/dev/null 2>&1 || true
+	command -v ip6tables >/dev/null 2>&1 && _wg_fw3_rules -D "$_dev" run
+	_wg_kick_firewall
 }
 
 wg_apply_firewall() {
@@ -348,37 +588,33 @@ wg_apply_dev_hostside() {
 	return 0
 }
 
-wg_apply_glinet() {
-	_srv="$1"
-	_dev="$2"
+# Apply IPv4-only enforcement for one section. _src is 'glinet' or 'netifd'.
+_wg_apply_section() {
+	_src="$1"; _name="$2"; _dev="$3"
 	wg_iface_is_valid "$_dev" || {
-		_wg_warn "refusing to act on invalid iface name '$_dev' for $_srv"
+		_wg_warn "refusing to act on invalid iface name '$_dev' for $_name"
 		return 1
 	}
-	wg_pin_glinet_ipv4 "$_srv"
+	case "$_src" in
+		glinet) wg_snapshot_glinet "$_name"; wg_pin_glinet_ipv4 "$_name" ;;
+		netifd) wg_snapshot_netifd "$_name"; wg_pin_netifd_ipv4 "$_name" ;;
+		*)      return 1 ;;
+	esac
 	wg_apply_dev_hostside "$_dev"
 	mkdir -p "$WG_NOIPV6_STATE_DIR"
-	printf '%s\n' "$_dev" > "${WG_NOIPV6_STATE_DIR}/glinet-${_srv}.dev"
+	printf '%s\n' "$_dev" > "${WG_NOIPV6_STATE_DIR}/${_src}-${_name}.dev"
+	_wg_log "enforced IPv4-only on ${_src}/${_name} (${_dev})"
 }
 
-wg_apply_netifd() {
-	_iface="$1"
-	_dev="$2"
-	wg_iface_is_valid "$_dev" || {
-		_wg_warn "refusing to act on invalid iface name '$_dev' for $_iface"
-		return 1
-	}
-	wg_pin_netifd_ipv4 "$_iface"
-	wg_apply_dev_hostside "$_dev"
-	mkdir -p "$WG_NOIPV6_STATE_DIR"
-	printf '%s\n' "$_dev" > "${WG_NOIPV6_STATE_DIR}/netifd-${_iface}.dev"
-}
+wg_apply_glinet() { _wg_apply_section glinet "$@"; }
+wg_apply_netifd() { _wg_apply_section netifd "$@"; }
 
 wg_clear_dev() {
 	_dev="$1"
 	wg_iface_is_valid "$_dev" || return 1
 	wg_remove_sysctl "$_dev"
 	wg_remove_firewall "$_dev"
+	_wg_log "removed enforcement on ${_dev}"
 }
 
 # Tear down enforcement using the on-disk state file as the source of
@@ -395,19 +631,26 @@ _wg_teardown_section() {
 }
 
 # Reconcile every WG server / interface against the global IPv6 state.
+# Always emits exactly one summary line via _wg_say so the caller -- procd
+# trigger, hotplug, or interactive shell -- can see what was done.
 wg_sync_all() {
 	mkdir -p "$WG_NOIPV6_STATE_DIR"
 
 	_off=0
 	[ "$(wg_global_ipv6_enabled)" = "0" ] && _off=1
 
+	_g_apply=0; _n_apply=0
+	_g_restore=0; _n_restore=0
+
 	for _srv in $(wg_list_glinet_servers); do
 		_dev="$(wg_glinet_kernel_dev "$_srv")"
 		wg_iface_is_valid "$_dev" || continue
 		if [ "$_off" -eq 1 ]; then
-			wg_apply_glinet "$_srv" "$_dev"
+			wg_apply_glinet "$_srv" "$_dev" && _g_apply=$((_g_apply+1))
 		else
 			_wg_teardown_section "${WG_NOIPV6_STATE_DIR}/glinet-${_srv}.dev" "$_dev"
+			[ -f "$(_wg_snap_path_glinet "$_srv")" ] && _g_restore=$((_g_restore+1))
+			wg_restore_glinet "$_srv"
 		fi
 	done
 
@@ -415,16 +658,38 @@ wg_sync_all() {
 		_dev="$(wg_netifd_kernel_dev "$_iface")"
 		wg_iface_is_valid "$_dev" || continue
 		if [ "$_off" -eq 1 ]; then
-			wg_apply_netifd "$_iface" "$_dev"
+			wg_apply_netifd "$_iface" "$_dev" && _n_apply=$((_n_apply+1))
 		else
 			wg_unpin_netifd_ipv4 "$_iface"
 			_wg_teardown_section "${WG_NOIPV6_STATE_DIR}/netifd-${_iface}.dev" "$_dev"
+			[ -f "$(_wg_snap_path_netifd "$_iface")" ] && _n_restore=$((_n_restore+1))
+			wg_restore_netifd "$_iface"
 		fi
 	done
+
+	if [ "$_off" -eq 1 ]; then
+		if [ $((_g_apply + _n_apply)) -eq 0 ]; then
+			_wg_say "sync: global IPv6 disabled; no WireGuard sections to enforce"
+		else
+			_wg_say "sync: global IPv6 disabled; enforced IPv4-only on ${_g_apply} glinet + ${_n_apply} netifd section(s)"
+		fi
+	elif [ $((_g_restore + _n_restore)) -eq 0 ]; then
+		_wg_say "sync: global IPv6 enabled; nothing to restore"
+	else
+		_wg_say "sync: global IPv6 enabled; restored ${_g_restore} glinet + ${_n_restore} netifd section(s) from snapshot"
+	fi
 }
 
-# Remove every drop-in this package may have installed (used by prerm).
+# Package prerm helper. Restore everything to the pre-install state without
+# touching the global IPv6 toggle. Step-by-step in code below.
 wg_clear_all() {
+	_wg_say "uninstall: starting full restore"
+
+	_g_total="$(_wg_count_snaps glinet)"
+	_n_total="$(_wg_count_snaps netifd)"
+
+	# 1. Tear down host-side enforcement BEFORE reloading wireguard_server,
+	#    so the daemon can re-add v6 addresses to a re-enabled kernel device.
 	if [ -d "$WG_NOIPV6_STATE_DIR" ]; then
 		for _f in "$WG_NOIPV6_STATE_DIR"/*.dev; do
 			[ -f "$_f" ] || continue
@@ -438,6 +703,8 @@ wg_clear_all() {
 	          "$WG_NOIPV6_FW3_DIR"/wg-noipv6-*.sh; do
 		[ -f "$_f" ] && rm -f "$_f"
 	done
+
+	# 2. Drop our firewall UCI includes.
 	_changed=0
 	for _i in $(uci -q show firewall 2>/dev/null \
 			| awk -F. '/^firewall\.wg_noipv6_/ { sub(/=.*/, "", $2); print $2 }' \
@@ -445,6 +712,22 @@ wg_clear_all() {
 		uci -q delete "firewall.${_i}" 2>/dev/null && _changed=1
 	done
 	[ "$_changed" -eq 1 ] && uci -q commit firewall
-	/etc/init.d/firewall reload >/dev/null 2>&1 || true
+
+	# 3. Reload firewall + re-apply system sysctls so /proc reflects only
+	#    what the user actually wants.
+	_wg_kick_firewall
 	sysctl --system >/dev/null 2>&1 || true
+
+	# 4. Restore UCI snapshots; wg_restore_glinet kicks wireguard_server.
+	wg_restore_all
+
+	# 5. Reload netifd only when something was put back into network UCI.
+	[ "$_n_total" -gt 0 ] && _wg_kick_network
+
+	# 6. Drop on-disk backup + state.
+	rm -rf "$WG_NOIPV6_BACKUP_DIR" 2>/dev/null || true
+	rmdir /etc/wg-noipv6 2>/dev/null || true
+	rm -rf "$WG_NOIPV6_STATE_DIR" 2>/dev/null || true
+
+	_wg_say "uninstall: complete; restored ${_g_total} glinet + ${_n_total} netifd section(s)"
 }

--- a/gl-sdk4-wireguard-ipv4-only/files/usr/lib/wg-noipv6/functions.sh
+++ b/gl-sdk4-wireguard-ipv4-only/files/usr/lib/wg-noipv6/functions.sh
@@ -170,15 +170,34 @@ _wg_count_snaps() {
 }
 
 # Best-effort init.d reloads. Safe no-op when the script is absent.
+#
+# When _WG_NOIPV6_DEFER_KICK=1 is set in the environment of the caller,
+# the kick is skipped and the request is recorded in _WG_NOIPV6_PENDING_*
+# so the caller can issue a single coalesced reload at the end of a
+# multi-step operation (see wg_clear_all). This avoids cascading firewall
+# / wireguard_server / network reloads which on GL.iNet 4.x can leave the
+# router with broken outbound DNS for several seconds.
 _wg_kick_wgserver() {
+	if [ "${_WG_NOIPV6_DEFER_KICK:-0}" = "1" ]; then
+		_WG_NOIPV6_PENDING_WGSERVER=1
+		return 0
+	fi
 	[ -x /etc/init.d/wireguard_server ] && \
 		/etc/init.d/wireguard_server reload >/dev/null 2>&1 || true
 }
 _wg_kick_network() {
+	if [ "${_WG_NOIPV6_DEFER_KICK:-0}" = "1" ]; then
+		_WG_NOIPV6_PENDING_NETWORK=1
+		return 0
+	fi
 	[ -x /etc/init.d/network ] && \
 		/etc/init.d/network reload >/dev/null 2>&1 || true
 }
 _wg_kick_firewall() {
+	if [ "${_WG_NOIPV6_DEFER_KICK:-0}" = "1" ]; then
+		_WG_NOIPV6_PENDING_FIREWALL=1
+		return 0
+	fi
 	[ -x /etc/init.d/firewall ] && \
 		/etc/init.d/firewall reload >/dev/null 2>&1 || true
 }
@@ -684,15 +703,29 @@ wg_sync_all() {
 }
 
 # Package prerm helper. Restore everything to the pre-install state without
-# touching the global IPv6 toggle. Step-by-step in code below.
+# touching the global IPv6 toggle.
+#
+# IMPORTANT: defer all init.d reloads until the very end and issue at most
+# one each, in safe order (firewall -> wireguard_server -> network). On
+# GL.iNet 4.x, multiple cascading firewall reloads overlapping with a
+# wireguard_server reload can leave the router's own outbound traffic
+# (including DNS) blackholed for several seconds.
 wg_clear_all() {
 	_wg_say "uninstall: starting full restore"
 
 	_g_total="$(_wg_count_snaps glinet)"
 	_n_total="$(_wg_count_snaps netifd)"
 
-	# 1. Tear down host-side enforcement BEFORE reloading wireguard_server,
-	#    so the daemon can re-add v6 addresses to a re-enabled kernel device.
+	# Defer every kick from here on; we'll coalesce at the end.
+	_WG_NOIPV6_DEFER_KICK=1
+	_WG_NOIPV6_PENDING_FIREWALL=0
+	_WG_NOIPV6_PENDING_WGSERVER=0
+	_WG_NOIPV6_PENDING_NETWORK=0
+	export _WG_NOIPV6_DEFER_KICK
+
+	# 1. Tear down host-side enforcement (sysctl drop-ins, fw4 nft drop-ins,
+	#    fw3 scripts). wg_clear_dev will set _WG_NOIPV6_PENDING_FIREWALL=1
+	#    via _wg_kick_firewall instead of reloading immediately.
 	if [ -d "$WG_NOIPV6_STATE_DIR" ]; then
 		for _f in "$WG_NOIPV6_STATE_DIR"/*.dev; do
 			[ -f "$_f" ] || continue
@@ -701,33 +734,47 @@ wg_clear_all() {
 			rm -f "$_f"
 		done
 	fi
+	# Belt-and-suspenders: drop any leftover drop-in files whose state file
+	# was already gone (e.g. someone deleted /var/run by hand).
 	for _f in "$WG_NOIPV6_SYSCTL_DIR"/99-wg-noipv6-*.conf \
 	          "$WG_NOIPV6_NFT_DIR"/99-wg-noipv6-*.nft \
 	          "$WG_NOIPV6_FW3_DIR"/wg-noipv6-*.sh; do
-		[ -f "$_f" ] && rm -f "$_f"
+		[ -f "$_f" ] || continue
+		rm -f "$_f"
+		_WG_NOIPV6_PENDING_FIREWALL=1
 	done
 
-	# 2. Drop our firewall UCI includes.
+	# 2. Drop our firewall UCI includes (fw3 case). One commit if anything
+	#    changed; the firewall reload is still deferred.
 	_changed=0
 	for _i in $(uci -q show firewall 2>/dev/null \
 			| awk -F. '/^firewall\.wg_noipv6_/ { sub(/=.*/, "", $2); print $2 }' \
 			| sort -u); do
 		uci -q delete "firewall.${_i}" 2>/dev/null && _changed=1
 	done
-	[ "$_changed" -eq 1 ] && uci -q commit firewall
+	if [ "$_changed" -eq 1 ]; then
+		uci -q commit firewall
+		_WG_NOIPV6_PENDING_FIREWALL=1
+	fi
 
-	# 3. Reload firewall + re-apply system sysctls so /proc reflects only
-	#    what the user actually wants.
-	_wg_kick_firewall
-	sysctl --system >/dev/null 2>&1 || true
-
-	# 4. Restore UCI snapshots; wg_restore_glinet kicks wireguard_server.
+	# 3. Restore UCI snapshots. wg_restore_glinet will set
+	#    _WG_NOIPV6_PENDING_WGSERVER via the deferred kick rather than
+	#    reloading wireguard_server once per server.
 	wg_restore_all
+	[ "$_n_total" -gt 0 ] && _WG_NOIPV6_PENDING_NETWORK=1
 
-	# 5. Reload netifd only when something was put back into network UCI.
-	[ "$_n_total" -gt 0 ] && _wg_kick_network
+	# 4. Coalesced reloads, in the only safe order:
+	#    a) firewall first -- our drop-ins must be gone before
+	#       wireguard_server tries to bring wgserver back with v6 addrs.
+	#    b) wireguard_server next -- so the daemon re-emits its own zone
+	#       on top of a clean firewall.
+	#    c) network last -- only when netifd UCI was actually mutated.
+	unset _WG_NOIPV6_DEFER_KICK
+	[ "$_WG_NOIPV6_PENDING_FIREWALL" = "1" ] && _wg_kick_firewall
+	[ "$_WG_NOIPV6_PENDING_WGSERVER" = "1" ] && _wg_kick_wgserver
+	[ "$_WG_NOIPV6_PENDING_NETWORK"  = "1" ] && _wg_kick_network
 
-	# 6. Drop on-disk backup + state.
+	# 5. Drop on-disk backup + state.
 	rm -rf "$WG_NOIPV6_BACKUP_DIR" 2>/dev/null || true
 	rmdir /etc/wg-noipv6 2>/dev/null || true
 	rm -rf "$WG_NOIPV6_STATE_DIR" 2>/dev/null || true

--- a/gl-sdk4-wireguard-ipv4-only/files/usr/sbin/wg-noipv6
+++ b/gl-sdk4-wireguard-ipv4-only/files/usr/sbin/wg-noipv6
@@ -10,7 +10,7 @@ export LC_ALL
 
 usage() {
 	cat <<USAGE
-Usage: wg-noipv6 [sync|apply <dev>|clear <dev>|clear-all|status]
+Usage: wg-noipv6 [sync|apply <dev>|clear <dev>|clear-all|status|cron-tick]
 
   sync          (default) reconcile every WG server section against the
                 global IPv6 state shown on /#/ipv6.
@@ -18,6 +18,8 @@ Usage: wg-noipv6 [sync|apply <dev>|clear <dev>|clear-all|status]
   clear <dev>   remove IPv4-only state for kernel device <dev>.
   clear-all     remove every drop-in installed by this package.
   status        print PASS/FAIL audit per WG server section.
+  cron-tick     periodic safety-net for the /#/ipv6 toggle. Silent
+                unless the global IPv6 state changed since last tick.
 USAGE
 }
 
@@ -26,6 +28,35 @@ _need_dev() {
 		echo "wg-noipv6: invalid device name: ${1:-<empty>}" >&2
 		exit 1
 	}
+}
+
+# Periodic safety net for the /#/ipv6 toggle.
+#
+# Some GL.iNet 4.x firmware revisions only commit `glconfig.general.
+# enable_ipv6` on the disable path -- without an `ifdown wan6`, without a
+# `network` reload, and without a `ubus call service event ...` for the
+# glconfig package. None of our procd reload triggers or hotplugs see this
+# transition, so a slow-poll reconciler is the only fully reliable way to
+# notice it.
+#
+# Logs nothing unless the global state has actually changed since the
+# previous tick (delegated to wg_sync_all, which already emits one summary
+# line per real reconcile).
+cmd_cron_tick() {
+	_state_dir="$WG_NOIPV6_STATE_DIR"
+	_last_file="${_state_dir}/last-global"
+	mkdir -p "$_state_dir" 2>/dev/null || true
+
+	_cur="$(wg_global_ipv6_enabled)"
+	_last="$(cat "$_last_file" 2>/dev/null)"
+
+	if [ "$_cur" = "$_last" ]; then
+		return 0
+	fi
+
+	printf '%s\n' "$_cur" > "$_last_file"
+	WG_NOIPV6_QUIET=1 wg_sync_all
+	return 0
 }
 
 cmd_status() {
@@ -208,6 +239,9 @@ main() {
 		status)
 			cmd_status
 			exit $?
+			;;
+		cron-tick)
+			cmd_cron_tick
 			;;
 		help|-h|--help)
 			usage

--- a/gl-sdk4-wireguard-ipv4-only/files/usr/sbin/wg-noipv6
+++ b/gl-sdk4-wireguard-ipv4-only/files/usr/sbin/wg-noipv6
@@ -50,16 +50,43 @@ cmd_status() {
 		_dev="$(wg_glinet_kernel_dev "$_srv")"
 		_label="glinet/${_srv} (${_dev})"
 		if [ "$_global" = "enabled" ]; then
+			# Two PASS checks: nothing leftover from a previous enforce.
 			_snap="$(_wg_snap_path_glinet "$_srv")"
 			[ ! -f "$_snap" ] && _ok=0 || _ok=1
 			_pf "$_ok" "$_label" "no pending UCI snapshot to restore" \
-				"snapshot still present (un-restored): $_snap"
+				"snapshot still present (un-restored): $_snap -- run: wg-noipv6 sync"
 
 			if wg_iface_is_valid "$_dev"; then
 				[ ! -f "${WG_NOIPV6_SYSCTL_DIR}/99-wg-noipv6-${_dev}.conf" ] \
 					&& _ok=0 || _ok=1
 				_pf "$_ok" "$_label" "no stale sysctl drop-in" \
-					"stale sysctl drop-in present"
+					"stale sysctl drop-in present -- run: wg-noipv6 clear ${_dev}"
+			fi
+
+			# INFO lines: show what IPv6 is actually present so the user
+			# can confirm restore put things back the way they expect.
+			_v6srv="$(uci -q get "wireguard_server.${_srv}.address_v6" 2>/dev/null)"
+			if [ -n "$_v6srv" ]; then
+				printf '  [INFO] %s: UCI address_v6 = %s\n' "$_label" "$_v6srv"
+			else
+				printf '  [INFO] %s: UCI address_v6 not set\n' "$_label"
+			fi
+
+			_v6peers=0
+			for _p in $(wg_list_glinet_peers); do
+				for _key in client_ip allowed_ips; do
+					_cur="$(uci -q get "wireguard_server.${_p}.${_key}" 2>/dev/null)"
+					case "$_cur" in *:*) _v6peers=$((_v6peers+1));; esac
+				done
+			done
+			printf '  [INFO] %s: %d peer entry/entries contain IPv6\n' \
+				"$_label" "$_v6peers"
+
+			if wg_iface_is_valid "$_dev" && [ -d "/sys/class/net/$_dev" ]; then
+				_live=$(ip -6 addr show dev "$_dev" 2>/dev/null \
+						| awk '/inet6/ && $2 !~ /^fe80/' | wc -l)
+				printf '  [INFO] %s: %d global IPv6 address(es) on kernel dev\n' \
+					"$_label" "$_live"
 			fi
 			continue
 		fi
@@ -103,17 +130,33 @@ cmd_status() {
 			_snap="$(_wg_snap_path_netifd "$_iface")"
 			[ ! -f "$_snap" ] && _ok=0 || _ok=1
 			_pf "$_ok" "$_label" "no pending UCI snapshot to restore" \
-				"snapshot still present (un-restored): $_snap"
+				"snapshot still present (un-restored): $_snap -- run: wg-noipv6 sync"
 
 			[ "$(uci -q get "network.${_iface}.ipv6")" != "0" ] && _ok=0 || _ok=1
 			_pf "$_ok" "netifd/${_iface}" "ipv6 not pinned to 0" \
-				"ipv6=0 still pinned"
+				"ipv6=0 still pinned -- run: wg-noipv6 sync"
 
 			if wg_iface_is_valid "$_dev"; then
 				[ ! -f "${WG_NOIPV6_SYSCTL_DIR}/99-wg-noipv6-${_dev}.conf" ] \
 					&& _ok=0 || _ok=1
 				_pf "$_ok" "$_label" "no stale sysctl drop-in" \
-					"stale sysctl drop-in present"
+					"stale sysctl drop-in present -- run: wg-noipv6 clear ${_dev}"
+			fi
+
+			# INFO lines: show what IPv6 is actually present.
+			_v6addrs=0
+			_addrs="$(uci -q get "network.${_iface}.addresses" 2>/dev/null)"
+			for _a in $_addrs; do
+				case "$_a" in *:*) _v6addrs=$((_v6addrs+1));; esac
+			done
+			printf '  [INFO] %s: %d IPv6 address(es) in network UCI\n' \
+				"$_label" "$_v6addrs"
+
+			if wg_iface_is_valid "$_dev" && [ -d "/sys/class/net/$_dev" ]; then
+				_live=$(ip -6 addr show dev "$_dev" 2>/dev/null \
+						| awk '/inet6/ && $2 !~ /^fe80/' | wc -l)
+				printf '  [INFO] %s: %d global IPv6 address(es) on kernel dev\n' \
+					"$_label" "$_live"
 			fi
 			continue
 		fi

--- a/gl-sdk4-wireguard-ipv4-only/files/usr/sbin/wg-noipv6
+++ b/gl-sdk4-wireguard-ipv4-only/files/usr/sbin/wg-noipv6
@@ -50,7 +50,17 @@ cmd_status() {
 		_dev="$(wg_glinet_kernel_dev "$_srv")"
 		_label="glinet/${_srv} (${_dev})"
 		if [ "$_global" = "enabled" ]; then
-			printf '  [INFO] %s: no enforcement expected\n' "$_label"
+			_snap="$(_wg_snap_path_glinet "$_srv")"
+			[ ! -f "$_snap" ] && _ok=0 || _ok=1
+			_pf "$_ok" "$_label" "no pending UCI snapshot to restore" \
+				"snapshot still present (un-restored): $_snap"
+
+			if wg_iface_is_valid "$_dev"; then
+				[ ! -f "${WG_NOIPV6_SYSCTL_DIR}/99-wg-noipv6-${_dev}.conf" ] \
+					&& _ok=0 || _ok=1
+				_pf "$_ok" "$_label" "no stale sysctl drop-in" \
+					"stale sysctl drop-in present"
+			fi
 			continue
 		fi
 
@@ -90,7 +100,21 @@ cmd_status() {
 		_dev="$(wg_netifd_kernel_dev "$_iface")"
 		_label="netifd/${_iface} (${_dev})"
 		if [ "$_global" = "enabled" ]; then
-			printf '  [INFO] %s: no enforcement expected\n' "$_label"
+			_snap="$(_wg_snap_path_netifd "$_iface")"
+			[ ! -f "$_snap" ] && _ok=0 || _ok=1
+			_pf "$_ok" "$_label" "no pending UCI snapshot to restore" \
+				"snapshot still present (un-restored): $_snap"
+
+			[ "$(uci -q get "network.${_iface}.ipv6")" != "0" ] && _ok=0 || _ok=1
+			_pf "$_ok" "netifd/${_iface}" "ipv6 not pinned to 0" \
+				"ipv6=0 still pinned"
+
+			if wg_iface_is_valid "$_dev"; then
+				[ ! -f "${WG_NOIPV6_SYSCTL_DIR}/99-wg-noipv6-${_dev}.conf" ] \
+					&& _ok=0 || _ok=1
+				_pf "$_ok" "$_label" "no stale sysctl drop-in" \
+					"stale sysctl drop-in present"
+			fi
 			continue
 		fi
 
@@ -128,10 +152,12 @@ main() {
 		apply)
 			_need_dev "${1:-}"
 			wg_apply_dev_hostside "$1"
+			_wg_say "apply: enforced IPv4-only host-side state on $1"
 			;;
 		clear)
 			_need_dev "${1:-}"
 			wg_clear_dev "$1"
+			_wg_say "clear: removed host-side enforcement on $1"
 			;;
 		clear-all)
 			wg_clear_all

--- a/gl-sdk4-wireguard-ipv4-only/files/usr/sbin/wg-noipv6
+++ b/gl-sdk4-wireguard-ipv4-only/files/usr/sbin/wg-noipv6
@@ -1,28 +1,6 @@
 #!/bin/sh
 # shellcheck shell=ash
-#
-# /usr/sbin/wg-noipv6
-#
-# CLI entry point for gl-sdk4-wireguard-ipv4-only. Subcommands:
-#
-#   sync                Re-evaluate every wireguard server section's
-#                       enable_ipv6 toggle and apply / clear state.
-#                       This is the default and is what the init.d
-#                       service, hotplug scripts and RPC adapter call.
-#
-#   apply <dev>         Force-apply IPv4-only enforcement on <dev>
-#                       without touching UCI. Used by the net hotplug
-#                       to re-pin state after the kernel device
-#                       (re-)appears.
-#
-#   clear <dev>         Tear down enforcement for <dev>.
-#
-#   clear-all           Remove every drop-in this package owns.
-#                       Used by the package prerm script.
-#
-#   status              Print one PASS/FAIL line per WG server
-#                       section. Exit code 0 = compliant, 2 = drift,
-#                       3 = no WG server configured.
+# wg-noipv6 -- IPv4-only enforcement CLI.
 
 set -u
 LC_ALL=C
@@ -34,9 +12,8 @@ usage() {
 	cat <<USAGE
 Usage: wg-noipv6 [sync|apply <dev>|clear <dev>|clear-all|status]
 
-  sync          (default) re-evaluate enable_ipv6 for every WG server
-                section in /etc/config/wireguard_server and
-                /etc/config/network and apply or clear enforcement.
+  sync          (default) reconcile every WG server section against the
+                global IPv6 state shown on /#/ipv6.
   apply <dev>   force-apply IPv4-only state for kernel device <dev>.
   clear <dev>   remove IPv4-only state for kernel device <dev>.
   clear-all     remove every drop-in installed by this package.
@@ -44,87 +21,86 @@ Usage: wg-noipv6 [sync|apply <dev>|clear <dev>|clear-all|status]
 USAGE
 }
 
+_need_dev() {
+	wg_iface_is_valid "${1:-}" || {
+		echo "wg-noipv6: invalid device name: ${1:-<empty>}" >&2
+		exit 1
+	}
+}
+
 cmd_status() {
 	_pass=0; _fail=0; _seen=0
+
+	_global="enabled"
+	[ "$(wg_global_ipv6_enabled)" = "0" ] && _global="disabled"
+	printf '  [INFO] global IPv6: %s (driven by /#/ipv6)\n' "$_global"
+
+	_pf() {
+		if [ "$1" -eq 0 ]; then
+			printf '  [PASS] %s: %s\n' "$2" "$3"
+			_pass=$((_pass+1))
+		else
+			printf '  [FAIL] %s: %s\n' "$2" "$4"
+			_fail=$((_fail+1))
+		fi
+	}
 
 	for _srv in $(wg_list_glinet_servers); do
 		_seen=$((_seen+1))
 		_dev="$(wg_glinet_kernel_dev "$_srv")"
-		_want="$(wg_glinet_enable_ipv6 "$_srv")"
-		if [ "$_want" = "1" ]; then
-			printf '  [INFO] glinet/%s (%s): enable_ipv6=1, no enforcement expected\n' "$_srv" "$_dev"
+		_label="glinet/${_srv} (${_dev})"
+		if [ "$_global" = "enabled" ]; then
+			printf '  [INFO] %s: no enforcement expected\n' "$_label"
 			continue
 		fi
-		# enable_ipv6 = 0 => expect enforcement
-		if wg_iface_is_valid "$_dev" \
-				&& [ -f "${WG_NOIPV6_SYSCTL_DIR}/99-wg-noipv6-${_dev}.conf" ]; then
-			printf '  [PASS] glinet/%s (%s): sysctl drop-in present\n' "$_srv" "$_dev"
-			_pass=$((_pass+1))
-		else
-			printf '  [FAIL] glinet/%s (%s): sysctl drop-in missing\n' "$_srv" "$_dev"
-			_fail=$((_fail+1))
-		fi
+
+		wg_iface_is_valid "$_dev" \
+			&& [ -f "${WG_NOIPV6_SYSCTL_DIR}/99-wg-noipv6-${_dev}.conf" ] \
+			&& _ok=0 || _ok=1
+		_pf "$_ok" "$_label" "sysctl drop-in present" "sysctl drop-in missing"
+
 		_v6srv="$(uci -q get "wireguard_server.${_srv}.address_v6" 2>/dev/null)"
-		if [ -z "$_v6srv" ]; then
-			printf '  [PASS] glinet/%s: address_v6 cleared\n' "$_srv"
-			_pass=$((_pass+1))
-		else
-			printf '  [FAIL] glinet/%s: address_v6 still set (%s)\n' "$_srv" "$_v6srv"
-			_fail=$((_fail+1))
-		fi
+		[ -z "$_v6srv" ] && _ok=0 || _ok=1
+		_pf "$_ok" "glinet/${_srv}" "address_v6 cleared" "address_v6 still set ($_v6srv)"
+
 		_bad=0
 		for _p in $(wg_list_glinet_peers); do
 			for _key in client_ip allowed_ips; do
 				_cur="$(uci -q get "wireguard_server.${_p}.${_key}" 2>/dev/null)"
-				[ -n "$_cur" ] || continue
 				case "$_cur" in *:*) _bad=$((_bad+1));; esac
 			done
 		done
-		if [ "$_bad" -eq 0 ]; then
-			printf '  [PASS] glinet/%s: peer client_ip/allowed_ips IPv4-only\n' "$_srv"
-			_pass=$((_pass+1))
-		else
-			printf '  [FAIL] glinet/%s: %d peer entries still contain IPv6\n' "$_srv" "$_bad"
-			_fail=$((_fail+1))
-		fi
+		[ "$_bad" -eq 0 ] && _ok=0 || _ok=1
+		_pf "$_ok" "glinet/${_srv}" "peer client_ip/allowed_ips IPv4-only" \
+			"$_bad peer entries still contain IPv6"
+
 		if [ -d "/sys/class/net/$_dev" ]; then
 			_live=$(ip -6 addr show dev "$_dev" 2>/dev/null \
 					| awk '/inet6/ && $2 !~ /^fe80/' | wc -l)
-			if [ "$_live" -eq 0 ]; then
-				printf '  [PASS] glinet/%s (%s): no global IPv6 on kernel dev\n' "$_srv" "$_dev"
-				_pass=$((_pass+1))
-			else
-				printf '  [FAIL] glinet/%s (%s): %d global IPv6 still on kernel dev\n' "$_srv" "$_dev" "$_live"
-				_fail=$((_fail+1))
-			fi
+			[ "$_live" -eq 0 ] && _ok=0 || _ok=1
+			_pf "$_ok" "$_label" "no global IPv6 on kernel dev" \
+				"$_live global IPv6 still on kernel dev"
 		else
-			printf '  [INFO] glinet/%s (%s): kernel dev not present\n' "$_srv" "$_dev"
+			printf '  [INFO] %s: kernel dev not present\n' "$_label"
 		fi
 	done
 
 	for _iface in $(wg_list_netifd_ifaces); do
 		_seen=$((_seen+1))
 		_dev="$(wg_netifd_kernel_dev "$_iface")"
-		_want="$(wg_netifd_enable_ipv6 "$_iface")"
-		if [ "$_want" = "1" ]; then
-			printf '  [INFO] netifd/%s (%s): enable_ipv6=1, no enforcement expected\n' "$_iface" "$_dev"
+		_label="netifd/${_iface} (${_dev})"
+		if [ "$_global" = "enabled" ]; then
+			printf '  [INFO] %s: no enforcement expected\n' "$_label"
 			continue
 		fi
-		if wg_iface_is_valid "$_dev" \
-				&& [ -f "${WG_NOIPV6_SYSCTL_DIR}/99-wg-noipv6-${_dev}.conf" ]; then
-			printf '  [PASS] netifd/%s (%s): sysctl drop-in present\n' "$_iface" "$_dev"
-			_pass=$((_pass+1))
-		else
-			printf '  [FAIL] netifd/%s (%s): sysctl drop-in missing\n' "$_iface" "$_dev"
-			_fail=$((_fail+1))
-		fi
-		if [ "$(uci -q get "network.${_iface}.ipv6")" = "0" ]; then
-			printf '  [PASS] netifd/%s: ipv6=0\n' "$_iface"
-			_pass=$((_pass+1))
-		else
-			printf '  [FAIL] netifd/%s: ipv6 not pinned to 0\n' "$_iface"
-			_fail=$((_fail+1))
-		fi
+
+		wg_iface_is_valid "$_dev" \
+			&& [ -f "${WG_NOIPV6_SYSCTL_DIR}/99-wg-noipv6-${_dev}.conf" ] \
+			&& _ok=0 || _ok=1
+		_pf "$_ok" "$_label" "sysctl drop-in present" "sysctl drop-in missing"
+
+		[ "$(uci -q get "network.${_iface}.ipv6")" = "0" ] && _ok=0 || _ok=1
+		_pf "$_ok" "netifd/${_iface}" "ipv6=0" "ipv6 not pinned to 0"
 	done
 
 	if [ "$_seen" -eq 0 ]; then
@@ -150,28 +126,12 @@ main() {
 			wg_sync_all
 			;;
 		apply)
-			_dev="${1:-}"
-			wg_iface_is_valid "$_dev" || {
-				echo "wg-noipv6: invalid device name: ${_dev:-<empty>}" >&2
-				exit 1
-			}
-			# Apply only host-side enforcement; UCI pinning is done
-			# via `sync`. This is what the net hotplug calls when a
-			# WG kernel device shows up.
-			wg_apply_sysctl "$_dev"
-			wg_apply_firewall "$_dev"
-			_n="$(wg_strip_live_ipv6 "$_dev")"
-			[ "$_n" -gt 0 ] && _wg_log "apply: removed $_n IPv6 address(es) from $_dev"
-			_p="$(wg_reconcile_kernel_peers_ipv4 "$_dev")"
-			[ "$_p" -gt 0 ] && _wg_log "apply: reconciled $_p kernel peer(s) on $_dev"
+			_need_dev "${1:-}"
+			wg_apply_dev_hostside "$1"
 			;;
 		clear)
-			_dev="${1:-}"
-			wg_iface_is_valid "$_dev" || {
-				echo "wg-noipv6: invalid device name: ${_dev:-<empty>}" >&2
-				exit 1
-			}
-			wg_clear_dev "$_dev"
+			_need_dev "${1:-}"
+			wg_clear_dev "$1"
 			;;
 		clear-all)
 			wg_clear_all

--- a/gl-sdk4-wireguard-ipv4-only/files/usr/sbin/wg-noipv6
+++ b/gl-sdk4-wireguard-ipv4-only/files/usr/sbin/wg-noipv6
@@ -1,0 +1,193 @@
+#!/bin/sh
+# shellcheck shell=ash
+#
+# /usr/sbin/wg-noipv6
+#
+# CLI entry point for gl-sdk4-wireguard-ipv4-only. Subcommands:
+#
+#   sync                Re-evaluate every wireguard server section's
+#                       enable_ipv6 toggle and apply / clear state.
+#                       This is the default and is what the init.d
+#                       service, hotplug scripts and RPC adapter call.
+#
+#   apply <dev>         Force-apply IPv4-only enforcement on <dev>
+#                       without touching UCI. Used by the net hotplug
+#                       to re-pin state after the kernel device
+#                       (re-)appears.
+#
+#   clear <dev>         Tear down enforcement for <dev>.
+#
+#   clear-all           Remove every drop-in this package owns.
+#                       Used by the package prerm script.
+#
+#   status              Print one PASS/FAIL line per WG server
+#                       section. Exit code 0 = compliant, 2 = drift,
+#                       3 = no WG server configured.
+
+set -u
+LC_ALL=C
+export LC_ALL
+
+. /usr/lib/wg-noipv6/functions.sh
+
+usage() {
+	cat <<USAGE
+Usage: wg-noipv6 [sync|apply <dev>|clear <dev>|clear-all|status]
+
+  sync          (default) re-evaluate enable_ipv6 for every WG server
+                section in /etc/config/wireguard_server and
+                /etc/config/network and apply or clear enforcement.
+  apply <dev>   force-apply IPv4-only state for kernel device <dev>.
+  clear <dev>   remove IPv4-only state for kernel device <dev>.
+  clear-all     remove every drop-in installed by this package.
+  status        print PASS/FAIL audit per WG server section.
+USAGE
+}
+
+cmd_status() {
+	_pass=0; _fail=0; _seen=0
+
+	for _srv in $(wg_list_glinet_servers); do
+		_seen=$((_seen+1))
+		_dev="$(wg_glinet_kernel_dev "$_srv")"
+		_want="$(wg_glinet_enable_ipv6 "$_srv")"
+		if [ "$_want" = "1" ]; then
+			printf '  [INFO] glinet/%s (%s): enable_ipv6=1, no enforcement expected\n' "$_srv" "$_dev"
+			continue
+		fi
+		# enable_ipv6 = 0 => expect enforcement
+		if wg_iface_is_valid "$_dev" \
+				&& [ -f "${WG_NOIPV6_SYSCTL_DIR}/99-wg-noipv6-${_dev}.conf" ]; then
+			printf '  [PASS] glinet/%s (%s): sysctl drop-in present\n' "$_srv" "$_dev"
+			_pass=$((_pass+1))
+		else
+			printf '  [FAIL] glinet/%s (%s): sysctl drop-in missing\n' "$_srv" "$_dev"
+			_fail=$((_fail+1))
+		fi
+		_v6srv="$(uci -q get "wireguard_server.${_srv}.address_v6" 2>/dev/null)"
+		if [ -z "$_v6srv" ]; then
+			printf '  [PASS] glinet/%s: address_v6 cleared\n' "$_srv"
+			_pass=$((_pass+1))
+		else
+			printf '  [FAIL] glinet/%s: address_v6 still set (%s)\n' "$_srv" "$_v6srv"
+			_fail=$((_fail+1))
+		fi
+		_bad=0
+		for _p in $(wg_list_glinet_peers); do
+			for _key in client_ip allowed_ips; do
+				_cur="$(uci -q get "wireguard_server.${_p}.${_key}" 2>/dev/null)"
+				[ -n "$_cur" ] || continue
+				case "$_cur" in *:*) _bad=$((_bad+1));; esac
+			done
+		done
+		if [ "$_bad" -eq 0 ]; then
+			printf '  [PASS] glinet/%s: peer client_ip/allowed_ips IPv4-only\n' "$_srv"
+			_pass=$((_pass+1))
+		else
+			printf '  [FAIL] glinet/%s: %d peer entries still contain IPv6\n' "$_srv" "$_bad"
+			_fail=$((_fail+1))
+		fi
+		if [ -d "/sys/class/net/$_dev" ]; then
+			_live=$(ip -6 addr show dev "$_dev" 2>/dev/null \
+					| awk '/inet6/ && $2 !~ /^fe80/' | wc -l)
+			if [ "$_live" -eq 0 ]; then
+				printf '  [PASS] glinet/%s (%s): no global IPv6 on kernel dev\n' "$_srv" "$_dev"
+				_pass=$((_pass+1))
+			else
+				printf '  [FAIL] glinet/%s (%s): %d global IPv6 still on kernel dev\n' "$_srv" "$_dev" "$_live"
+				_fail=$((_fail+1))
+			fi
+		else
+			printf '  [INFO] glinet/%s (%s): kernel dev not present\n' "$_srv" "$_dev"
+		fi
+	done
+
+	for _iface in $(wg_list_netifd_ifaces); do
+		_seen=$((_seen+1))
+		_dev="$(wg_netifd_kernel_dev "$_iface")"
+		_want="$(wg_netifd_enable_ipv6 "$_iface")"
+		if [ "$_want" = "1" ]; then
+			printf '  [INFO] netifd/%s (%s): enable_ipv6=1, no enforcement expected\n' "$_iface" "$_dev"
+			continue
+		fi
+		if wg_iface_is_valid "$_dev" \
+				&& [ -f "${WG_NOIPV6_SYSCTL_DIR}/99-wg-noipv6-${_dev}.conf" ]; then
+			printf '  [PASS] netifd/%s (%s): sysctl drop-in present\n' "$_iface" "$_dev"
+			_pass=$((_pass+1))
+		else
+			printf '  [FAIL] netifd/%s (%s): sysctl drop-in missing\n' "$_iface" "$_dev"
+			_fail=$((_fail+1))
+		fi
+		if [ "$(uci -q get "network.${_iface}.ipv6")" = "0" ]; then
+			printf '  [PASS] netifd/%s: ipv6=0\n' "$_iface"
+			_pass=$((_pass+1))
+		else
+			printf '  [FAIL] netifd/%s: ipv6 not pinned to 0\n' "$_iface"
+			_fail=$((_fail+1))
+		fi
+	done
+
+	if [ "$_seen" -eq 0 ]; then
+		printf '  [INFO] no WireGuard server configured\n'
+		return 3
+	fi
+	printf '\nsummary: %d PASS / %d FAIL\n' "$_pass" "$_fail"
+	[ "$_fail" -gt 0 ] && return 2
+	return 0
+}
+
+main() {
+	[ "$(id -u)" -eq 0 ] || {
+		echo "wg-noipv6: must run as root" >&2
+		exit 1
+	}
+
+	_cmd="${1:-sync}"
+	[ $# -gt 0 ] && shift
+
+	case "$_cmd" in
+		sync)
+			wg_sync_all
+			;;
+		apply)
+			_dev="${1:-}"
+			wg_iface_is_valid "$_dev" || {
+				echo "wg-noipv6: invalid device name: ${_dev:-<empty>}" >&2
+				exit 1
+			}
+			# Apply only host-side enforcement; UCI pinning is done
+			# via `sync`. This is what the net hotplug calls when a
+			# WG kernel device shows up.
+			wg_apply_sysctl "$_dev"
+			wg_apply_firewall "$_dev"
+			_n="$(wg_strip_live_ipv6 "$_dev")"
+			[ "$_n" -gt 0 ] && _wg_log "apply: removed $_n IPv6 address(es) from $_dev"
+			_p="$(wg_reconcile_kernel_peers_ipv4 "$_dev")"
+			[ "$_p" -gt 0 ] && _wg_log "apply: reconciled $_p kernel peer(s) on $_dev"
+			;;
+		clear)
+			_dev="${1:-}"
+			wg_iface_is_valid "$_dev" || {
+				echo "wg-noipv6: invalid device name: ${_dev:-<empty>}" >&2
+				exit 1
+			}
+			wg_clear_dev "$_dev"
+			;;
+		clear-all)
+			wg_clear_all
+			;;
+		status)
+			cmd_status
+			exit $?
+			;;
+		help|-h|--help)
+			usage
+			;;
+		*)
+			usage >&2
+			exit 1
+			;;
+	esac
+}
+
+main "$@"

--- a/gl-sdk4-wireguard-ipv4-only/version.mk
+++ b/gl-sdk4-wireguard-ipv4-only/version.mk
@@ -1,0 +1,29 @@
+#
+# Copyright (C) 2026 GL.iNet
+#
+# This is free software, licensed under the GNU General Public License v2.
+#
+
+define findrev
+  $(shell \
+    if git log -1 >/dev/null 2>/dev/null; then \
+      set -- $$(git log -1 --format="%ct %h" --abbrev=7 -- .); \
+      if [ -n "$$1" ]; then \
+        secs="$$(($$1 % 86400))"; \
+        yday="$$(date --utc --date="@$$1" "+%Y.%j")"; \
+        printf 'git-%s.%05d-%s' "$$yday" "$$secs" "$$2"; \
+      else \
+        echo "unknown"; \
+      fi; \
+    else \
+      ts=$$(find . -type f -printf '%T@\n' 2>/dev/null | sort -rn | head -n1 | cut -d. -f1); \
+      if [ -n "$$ts" ]; then \
+        secs="$$(($$ts % 86400))"; \
+        date="$$(date --utc --date="@$$ts" "+%Y%m%d")"; \
+        printf '%s.%05d' "$$date" "$$secs"; \
+      else \
+        echo "unknown"; \
+      fi; \
+    fi \
+  )
+endef


### PR DESCRIPTION
## Summary

Adds a new package, `gl-sdk4-wireguard-ipv4-only`, that keys IPv4-only WireGuard enforcement off the existing global IPv6 toggle on `/#/ipv6` — no new GUI control. When the user disables IPv6, the package strips IPv6 from every WireGuard server / netifd-WG section (kernel device, UCI, live peer programming, firewall) and saves snapshots so the original config can be fully restored when IPv6 is re-enabled or the package is removed.

Use case: customers who want IPv4-only WireGuard without manually editing UCI per peer, and who already use `/#/ipv6` as their single source of truth for IPv6 on the router.

## What it does, step by step

When `wg-noipv6 sync` runs:

1. Reads global IPv6 state via a 5-step detection chain:
   `glconfig.general.enable_ipv6` → `network.wan6.disabled` → `network.wan6.proto=none` → `network.wan6.auto=0` → default `1`.
2. If **disabled**, for every GL.iNet `wireguard_server` section and every netifd `proto=wireguard` interface:
   - Snapshot the IPv6 fields about to be stripped (mode 0600 under `/etc/wg-noipv6/backup/`).
   - Strip `address_v6`, IPv6 entries from peer `client_ip` / `allowed_ips`, and IPv6 entries from netifd `addresses`. Pin `network.<wg>.ipv6=0`.
   - Reconcile the live kernel device: re-program peer AllowedIPs to IPv4-only via `wg set ... allowed-ips`, refusing to clear a peer entirely.
   - Drop a sysctl drop-in (`/etc/sysctl.d/99-wg-noipv6-<dev>.conf`) setting `net.ipv6.conf.<dev>.disable_ipv6 = 1`.
   - Install firewall drop-ins: fw4 nft chains under `/etc/nftables.d/` if `nft`/`fw4` are present, else fw3 ip6tables script + UCI include.
3. If **enabled**, runs the inverse: restores UCI from snapshot, removes drop-ins, kicks `wireguard_server` to repush peer programming.

## Triggers (multiple, defense-in-depth)

The `/#/ipv6` toggle behaves inconsistently across firmware revisions, so the package listens through several channels:

- **procd reload triggers** on `wireguard_server`, `network`, `firewall`, `glconfig`.
- **Iface hotplug** (`/etc/hotplug.d/iface/99-wg-noipv6`) — reacts to `ifup` on tracked WG sections **and** to `ifup`/`ifdown` on `wan6` (the most reliable enable-side signal).
- **Net hotplug** (`/etc/hotplug.d/net/99-wg-noipv6`) — required because `wireguard_server` brings `wgserver` up without firing netifd `ifup`.
- **Cron-tick** (`* * * * * wg-noipv6 cron-tick`) — silent unless the global IPv6 state actually changed since last tick. Catches the disable path on firmware revisions where the GUI commits `glconfig.general.enable_ipv6=0` without firing any procd/hotplug event.

## Surfaces

- **CLI** (`/usr/sbin/wg-noipv6`): `sync`, `apply <dev>`, `clear <dev>`, `clear-all`, `status`, `cron-tick`. `status` prints PASS/FAIL audit per WG section with extra `[INFO]` lines (UCI `address_v6`, peer IPv6 count, live kernel-device IPv6 count) so you can confirm at a glance what's there.
- **JSON-RPC** (`/usr/lib/oui-httpd/rpc/wireguard_ipv4_only`): `get_status` returns `{global_ipv6_enabled, servers: [...]}`; `sync` triggers a reconcile.

## Uninstall safety

`opkg remove` runs `wg-noipv6 clear-all`, which:

- Tears down host-side enforcement (sysctl + fw4 nft + fw3 ip6tables drop-ins).
- Drops our firewall UCI includes.
- Restores every UCI snapshot.
- **Coalesces all init.d reloads** — at most one each of `firewall` → `wireguard_server` → `network`, in safe order, via a deferred-kick mode on the kick helpers. (Earlier iterations triggered cascading reloads that briefly blackholed the router's own outbound traffic, including DNS.)
- Cleans up backup dir, state dir, and the cron-tick crontab line.

## Validation

- `dash -n` clean on all 6 shell files.
- `shellcheck --shell=ash --severity=warning` clean (only the long-known SC2034 false-positives on `START`/`STOP`/`USE_PROCD` consumed by `/etc/rc.common`).
- `luac -p` clean on the JSON-RPC module.
- 13/13 global-IPv6 detection smoke tests pass across all 5 chain steps.
- 5/5 cron-tick state-machine smoke tests (no log spam on idle ticks; exactly one sync per real state transition).
- Soak-tested on a real GL-AXT1800 (IPQ60xx, OpenWrt 23.05-SNAPSHOT) across multiple OFF/ON cycles plus install/uninstall cycles.

## Files

```
gl-sdk4-wireguard-ipv4-only/
├── Makefile                                    BuildPackage; postinst enable+start; prerm clear-all
├── version.mk                                  findrev (mirrors gl-sdk4-fan)
├── README.md
└── files/
    ├── etc/init.d/wg-noipv6                    reload-only procd service (no daemon)
    ├── etc/hotplug.d/iface/99-wg-noipv6        netifd ifup/ifdown trigger (incl. wan6)
    ├── etc/hotplug.d/net/99-wg-noipv6          kernel netdev add trigger
    ├── etc/uci-defaults/80-wg-noipv6           first-boot bootstrap + cron install
    ├── usr/sbin/wg-noipv6                      CLI dispatcher
    ├── usr/lib/wg-noipv6/functions.sh          helpers, snapshot/restore, deferred kicks
    └── usr/lib/oui-httpd/rpc/wireguard_ipv4_only   Lua RPC (get_status, sync)
```

## Notes

- `PKGARCH:=all` (pure shell + Lua, no compiled artifacts).
- Only depends on `wireguard-tools`.
- No GUI changes required; the existing `/#/ipv6` toggle is the user-facing control.
- All log lines go to syslog as `daemon.notice` / `daemon.warn` under tag `wg-noipv6` (matches the conventions used by dropbear / mwan3 / dnscrypt-proxy).